### PR TITLE
Created Pointcloud preprocessing lib

### DIFF
--- a/lib/README.md
+++ b/lib/README.md
@@ -30,6 +30,7 @@ This project requires:
 - [PCL (Point Cloud Library)](http://pointclouds.org/documentation/) (for filtering and advanced visualization)
 - A modern C++ compiler supporting C++11 or later.
 
+## Download sample pointcloud from this link https://drive.google.com/file/d/1gQqce4ZqsO59hb1R1lowTViAK7js4DPa/view?usp=sharing
 ## Installation
 
 1. **Clone the repository:**
@@ -68,6 +69,13 @@ This project requires:
    ```
 
 ## Refrences
+## RUNNING THE TEST
+ For running test_hazard_metrices with visualization you need to run the following command
+   ./test_pointcloud_preprocessing
+ WIthout visualization you need to run the following command 
+   ./test_pointcloud_preprocessing --no-vis 
+    or change line 7 bool g_skipVisualization = false; to bool g_skipVisualization = true;
+
 ## Data Structuring Grid based
  1. create 3d grid
 
@@ -114,3 +122,77 @@ This project requires:
     Function name : pcl::PointCloud<PointT>::Ptr applyBilateralFilter(const typename pcl::PointCloud<PointT>::Ptr &cloud,double sigma_s,double sigma_r)
     Reference Link: https://pointclouds.org/documentation/classpcl_1_1_bilateral_filter.html
                     https://github.com/PointCloudLibrary/pcl/blob/master/filters/include/pcl/filters/bilateral.h#L56
+
+
+## HAZARD METRICES
+
+## RUNNING THE TEST
+ For running test_hazard_metrices with visualization you need to run the following command
+   ./test_hazard_metrices 
+ WIthout visualization you need to run the following command 
+    ./test_hazard_metrices --no-vis 
+    or change line 7 bool g_skipVisualization = false; to bool g_skipVisualization = true;
+
+ 1. Principal Component Analysis
+    Function name : PCLResult PrincipleComponentAnalysis(const std::string& file_path,
+                                          pcl::PointCloud<pcl::Normal>::Ptr normals,
+                                          float voxel_size = 0.45f,
+                                          float slope_threshold = 20.0f,  // degrees
+                                          int k = 10)  // k-nearest neighbors
+   Reference Link : https://pointclouds.org/documentation/classpcl_1_1_p_c_a.html
+
+ 2. RANSAC Plane Segmentation
+    OPEN3D 
+    Function name : OPEN3DResult RansacPlaneSegmentation(const std::string& file_path,
+                                                         double voxel_size,
+                                                         double distance_threshold,
+                                                         int ransac_n,
+                                                         int num_iterations)      
+    Reference Link: https://github.com/isl-org/Open3D/blob/main/examples/cpp/RegistrationRANSAC.cpp 
+                    https://pcl.readthedocs.io/projects/tutorials/en/latest/planar_segmentation.html         
+    PCL 
+    Function name : PCLResult performRANSAC(const std::string &file_path,
+                           float voxelSize = 0.05f,
+                           float distanceThreshold = 0.02f,
+                           int maxIterations = 100)
+    Reference Link : https://pointclouds.org/documentation/classpcl_1_1_s_a_c_segmentation.html
+ 
+ 3. PROSAC Plane Segmentation
+    PCL 
+    Function name : PCLResult performPROSAC(const std::string &file_path,
+                           float voxelSize = 0.05f,
+                           float distanceThreshold = 0.02f,
+                           int maxIterations = 100) 
+    Reference Link : https://pointclouds.org/documentation/classpcl_1_1_s_a_c_segmentation.html
+                     https://pcl.readthedocs.io/projects/tutorials/en/latest/planar_segmentation.html change method type to SAC_PROSAC
+ 
+ 4. Least Squares Plane Fitting
+    OPEN3D
+    Function name : OPEN3DResult LeastSquaresPlaneFitting(const std::string &file_path, double voxel_size, double distance_threshold)
+    Reference Link : 
+ 
+ 5. Least Of Median Squares Plane Fitting
+    PCL
+    Function name : PCLResult performLMEDS(const std::string &file_path,
+                           float voxelSize = 0.05f,
+                           float distanceThreshold = 0.02f,
+                           int maxIterations = 100)
+    Reference Link : https://pointclouds.org/documentation/classpcl_1_1_s_a_c_segmentation.html
+                     https://pcl.readthedocs.io/projects/tutorials/en/latest/planar_segmentation.html change method type to SAC_LMEDS
+ 
+ 6. Region Growing Segmentation
+    PCL
+    Function name : inline PCLResult regionGrowingSegmentation(
+                           const std::string &file_path,
+                           float voxel_leaf,
+                           int min_cluster_size = 50,         // Minimum number of points per cluster.
+                           int max_cluster_size = 1000000,      // Maximum number of points per cluster.
+                           int number_of_neighbours = 30,       // Nearest neighbours used in region growing.
+                           int normal_k_search = 50,            // K nearest neighbors for normal estimation.
+                           // Lower the smoothness threshold to about 2° (in radians) so only nearly identical normals join.
+                           float smoothness_threshold = 2.0 / 180.0 * M_PI,
+                            // Lower the curvature threshold to only allow points with very low curvature (indicative of flat surfaces).
+                           float curvature_threshold = 0.9,
+                           // Instead of a dot product threshold, provide an angle (in degrees). For instance, 20°.
+                           float horizontal_angle_threshold_deg = 10.0f)
+    Reference Link : https://pcl.readthedocs.io/projects/tutorials/en/latest/region_growing_segmentation.html

--- a/lib/README.md
+++ b/lib/README.md
@@ -129,9 +129,13 @@ This project requires:
 ## RUNNING THE TEST
  For running test_hazard_metrices with visualization you need to run the following command
    ./test_hazard_metrices 
- WIthout visualization you need to run the following command 
+
+ Without visualization you need to run the following command 
     ./test_hazard_metrices --no-vis 
     or change line 7 bool g_skipVisualization = false; to bool g_skipVisualization = true;
+
+ For running specific test for eg :PROSAC you can run it with 
+   ./test_hazard_metrices --gtest_filter=HazardMetricesTest.TestPROSAC
 
  1. Principal Component Analysis
     Function name : PCLResult PrincipleComponentAnalysis(const std::string& file_path,

--- a/lib/README.md
+++ b/lib/README.md
@@ -1,0 +1,116 @@
+# 3D Point Cloud Processing and Visualization
+
+This project demonstrates how to process and visualize point clouds using multiple libraries:
+- **Open3D** for 3D point cloud processing and visualization.
+- **OctoMap** for generating 3D occupancy maps.
+- **PCL (Point Cloud Library)** for filtering, downsampling, and visualizing point clouds.
+
+The code includes examples for:
+- Loading point clouds.
+- Downsampling using a voxel grid filter.
+- Creating 2D and 3D grid maps.
+- Building KD-Trees and Octrees.
+- Applying filters like Statistical Outlier Removal (SOR), Radius Outlier Removal, and Bilateral filtering.
+- Visualizing the results using both Open3D and PCL visualizers.
+- Converting point clouds to OctoMap format.
+
+## Table of Contents
+
+- [Dependencies](#dependencies)
+- [Installation](#installation)
+- [Usage](#usage)
+- [Code Structure](#code-structure)
+- [References](#references)
+
+## Dependencies
+
+This project requires:
+- [Open3D](http://www.open3d.org/) (for point cloud processing and visualization)
+- [OctoMap](https://octomap.github.io/) (for 3D occupancy mapping)
+- [PCL (Point Cloud Library)](http://pointclouds.org/documentation/) (for filtering and advanced visualization)
+- A modern C++ compiler supporting C++11 or later.
+
+## Installation
+
+1. **Clone the repository:**
+
+   ```bash
+   git clone https://github.com/athulkrishnaaei/Landing-Assist-Module-LAM
+   ```
+   change branch 
+
+   ```bash
+   git checkout pointcloud_preprocessing
+   ```
+
+
+2. **Change directory and build the project:**
+    
+   ```bash
+   cd Landing-Assist-Module-LAM/lib/preprocessing
+
+   mkdir build
+   
+   cd build
+   ```
+
+   ```bash
+   sudo cmake ..
+   ```
+
+   ```bash
+   sudo make -j
+   ```
+3. **Run the project:**
+
+   ```bash
+   ./main
+   ```
+
+## Refrences
+## Data Structuring Grid based
+ 1. create 3d grid
+
+    Function name : VoxelGridResult create_3d_grid(const std::string& filename, double voxel_size)
+    Link          : https://www.open3d.org/html/cpp_api/classopen3d_1_1geometry_1_1_voxel_grid.html#ae9239348e9de069abaf5912b92dd2b84
+
+ 2. create 2d grid
+    
+    Function name : VoxelGridResult create_2d_grid(const std::string& filename, double voxel_size)
+    Link          : http://pointclouds.org/documentation/classpcl_1_1_grid_minimum.html#details
+                    https://github.com/PointCloudLibrary/pcl/blob/master/filters/include/pcl/filters/grid_minimum.h
+
+## Data Structuring Tree based
+
+ 3. create kdtree
+    Function name : KDTreeResult create_kdtree(const std::string& filename, int K)
+    Link          : https://www.open3d.org/html/cpp_api/classopen3d_1_1geometry_1_1_k_d_tree_flann.html#ae9239348e9de069abaf5912b92dd2b84
+
+ 4. create octree   
+    Function name : OctreeResult create_octree(const std::string& filename, double voxel_size)
+    Link          : https://www.open3d.org/html/cpp_api/classopen3d_1_1geometry_1_1_octree.html#ae9239348e9de069abaf5912b92dd2b84
+
+## Filtering Downsampling
+
+ 5. apply voxel grid filter(voxel downsample)
+    Function name : std::shared_ptr<open3d::geometry::PointCloud> apply_voxel_grid_filter(const std::string& filename,double voxel_size) 
+    Link          : https://www.open3d.org/docs/0.11.0/cpp_api/classopen3d_1_1geometry_1_1_point_cloud.html#a50efddf2d460dccf3de46cd0d38071af
+
+## Filtering Outlier Removal
+
+ 6. apply statistical outlier removal
+    Function name :SORFilterResult apply_sor_filter(const std::string& filename,int nb_neighbors,double std_ratio)
+    Reference Link: https://www.open3d.org/docs/0.6.0/cpp_api/namespaceopen3d_1_1geometry.html#add56e2ec673de3b9289a25095763af6d
+                    https://github.com/isl-org/Open3D/blob/main/cpp/open3d/geometry/PointCloud.cpp#L602
+
+ 7. radius outlier removal
+    Function name :pcl::PointCloud<PointT>::Ptr applyRadiusFilter(const typename pcl::PointCloud<PointT>::Ptr &cloud,double radius_search,int min_neighbors)
+    Reference Link:  http://pointclouds.org/documentation/classpcl_1_1_radius_outlier_removal.html
+                     https://github.com/PointCloudLibrary/pcl/blob/master/filters/src/radius_outlier_removal.cpp#L47
+
+## Filtering Smoothing
+
+ 8. bilateral filter
+    Function name : pcl::PointCloud<PointT>::Ptr applyBilateralFilter(const typename pcl::PointCloud<PointT>::Ptr &cloud,double sigma_s,double sigma_r)
+    Reference Link: https://pointclouds.org/documentation/classpcl_1_1_bilateral_filter.html
+                    https://github.com/PointCloudLibrary/pcl/blob/master/filters/include/pcl/filters/bilateral.h#L56

--- a/lib/hazard_metrices/CMakeLists.txt
+++ b/lib/hazard_metrices/CMakeLists.txt
@@ -1,0 +1,100 @@
+cmake_minimum_required(VERSION 3.10)
+project(Preprocessing)
+
+# Use C++17
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+# ----------------------------------------------------------------------------
+# 1. Find OPEN3d,PCL and include the necessary modules
+#    (Add 'io' if you need loadPCDFile())
+# ----------------------------------------------------------------------------
+
+find_package(Open3D REQUIRED)
+
+find_package(PCL 1.4 REQUIRED COMPONENTS common filters io visualization segmentation surface integral_image_normal region_growing)
+include_directories(${PCL_INCLUDE_DIRS})
+add_definitions(${PCL_DEFINITIONS})
+
+find_package(octomap REQUIRED)  # This will set OCTOMAP_INCLUDE_DIRS & OCTOMAP_LIBRARIES
+include_directories(${OCTOMAP_INCLUDE_DIRS})
+# add_definitions(${OCTOMAP_DEFINITIONS})
+
+# ----------------------------------------------------------------------------
+# 2. Optionally, find OpenMP if needed for parallelization
+# ----------------------------------------------------------------------------
+find_package(OpenMP REQUIRED)
+if(OPENMP_FOUND)
+    # Let CMake automatically add the correct compile/link flags
+    # for OpenMP instead of manually using -fopenmp or -lgomp
+    # (This is the recommended modern approach)
+    message(STATUS "OpenMP found. Linking to OpenMP libraries.")
+endif()
+
+# ----------------------------------------------------------------------------
+# 3. Manually include other libraries' include paths
+#    (Only do this if you do NOT rely on pkg-config or CMake find_package
+#     for these libraries)
+# ----------------------------------------------------------------------------
+include_directories(
+   
+    /usr/local/include/eigen3
+    /usr/local/include/pcl-1.14
+
+)
+  
+# ----------------------------------------------------------------------------
+# 4. Create the executable
+# ----------------------------------------------------------------------------
+add_executable(main main.cpp)
+
+# ----------------------------------------------------------------------------
+# 5. Link libraries
+#    - PCL libraries (from find_package)
+#    - OpenMP (if found)
+#    - Other manually specified libraries
+# ----------------------------------------------------------------------------
+
+ 
+target_link_libraries(main
+    PRIVATE
+    Open3D::Open3D                  # -lOpen3D
+    ${PCL_LIBRARIES} 
+    ${OCTOMAP_LIBRARIES}  
+    octomap 
+    octomath
+    GL                     # -lGL
+    GLU                    # -lGLU
+    glfw                   # -lglfw
+    GLEW                   # -lGLEW
+    assimp                 # -lassimp
+    jsoncpp               # -ljsoncpp
+    jpeg                   # -ljpeg
+    png                    # -lpng
+    z                      # -lz
+    pthread                # -lpthread
+)
+
+add_executable(test_hazard_metrices test_hazard_metrices.cpp)
+target_link_libraries(test_hazard_metrices 
+    ${PCL_LIBRARIES} 
+    Open3D::Open3D 
+    octomap 
+    gtest 
+    gtest_main
+    GL                     # -lGL
+    GLU                    # -lGLU
+    glfw                   # -lglfw
+    GLEW                   # -lGLEW
+    assimp                 # -lassimp
+    jsoncpp               # -ljsoncpp
+    jpeg                   # -ljpeg
+    png                    # -lpng
+    z                      # -lz
+    pthread                # -lpthread
+)
+
+# Link OpenMP last to ensure correct symbol resolution
+if(OPENMP_FOUND)
+    target_link_libraries(main PRIVATE OpenMP::OpenMP_CXX)
+endif()

--- a/lib/hazard_metrices/CMakeLists.txt
+++ b/lib/hazard_metrices/CMakeLists.txt
@@ -6,8 +6,7 @@ set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 # ----------------------------------------------------------------------------
-# 1. Find OPEN3d,PCL and include the necessary modules
-#    (Add 'io' if you need loadPCDFile())
+# 1. Find OPEN3D, PCL, and include the necessary modules
 # ----------------------------------------------------------------------------
 
 find_package(Open3D REQUIRED)
@@ -16,82 +15,84 @@ find_package(PCL 1.4 REQUIRED COMPONENTS common filters io visualization segment
 include_directories(${PCL_INCLUDE_DIRS})
 add_definitions(${PCL_DEFINITIONS})
 
-find_package(octomap REQUIRED)  # This will set OCTOMAP_INCLUDE_DIRS & OCTOMAP_LIBRARIES
+find_package(octomap REQUIRED)  # Sets OCTOMAP_INCLUDE_DIRS & OCTOMAP_LIBRARIES
 include_directories(${OCTOMAP_INCLUDE_DIRS})
-# add_definitions(${OCTOMAP_DEFINITIONS})
 
 # ----------------------------------------------------------------------------
 # 2. Optionally, find OpenMP if needed for parallelization
 # ----------------------------------------------------------------------------
 find_package(OpenMP REQUIRED)
 if(OPENMP_FOUND)
-    # Let CMake automatically add the correct compile/link flags
-    # for OpenMP instead of manually using -fopenmp or -lgomp
-    # (This is the recommended modern approach)
     message(STATUS "OpenMP found. Linking to OpenMP libraries.")
 endif()
 
 # ----------------------------------------------------------------------------
 # 3. Manually include other libraries' include paths
-#    (Only do this if you do NOT rely on pkg-config or CMake find_package
-#     for these libraries)
 # ----------------------------------------------------------------------------
 include_directories(
-   
     /usr/local/include/eigen3
     /usr/local/include/pcl-1.14
-
 )
-  
+
 # ----------------------------------------------------------------------------
-# 4. Create the executable
+# 4. Find VTK components (required by Open3D's third-party VTK modules)
+# ----------------------------------------------------------------------------
+
+find_package(VTK REQUIRED) 
+# If you want to specify them, do:
+# find_package(VTK REQUIRED COMPONENTS FiltersGeneral FiltersModeling FiltersCore CommonDataModel CommonExecutionModel)
+
+
+set(CMAKE_EXE_LINKER_FLAGS
+    "${CMAKE_EXE_LINKER_FLAGS} -Wl,--copy-dt-needed-entries"
+)
+# ----------------------------------------------------------------------------
+# 5. Create the executables
 # ----------------------------------------------------------------------------
 add_executable(main main.cpp)
+add_executable(test_hazard_metrices test_hazard_metrices.cpp)
 
 # ----------------------------------------------------------------------------
-# 5. Link libraries
-#    - PCL libraries (from find_package)
-#    - OpenMP (if found)
-#    - Other manually specified libraries
+# 6. Link libraries
 # ----------------------------------------------------------------------------
-
- 
 target_link_libraries(main
     PRIVATE
-    Open3D::Open3D                  # -lOpen3D
+    Open3D::Open3D           # -lOpen3D
     ${PCL_LIBRARIES} 
     ${OCTOMAP_LIBRARIES}  
     octomap 
     octomath
-    GL                     # -lGL
-    GLU                    # -lGLU
-    glfw                   # -lglfw
-    GLEW                   # -lGLEW
-    assimp                 # -lassimp
-    jsoncpp               # -ljsoncpp
-    jpeg                   # -ljpeg
-    png                    # -lpng
-    z                      # -lz
-    pthread                # -lpthread
+    GL                       # -lGL
+    GLU                      # -lGLU
+    glfw                     # -lglfw
+    GLEW                     # -lGLEW
+    assimp                   # -lassimp
+    jsoncpp                 # -ljsoncpp
+    jpeg                     # -ljpeg
+    png                      # -lpng
+    z                        # -lz
+    pthread                  # -lpthread
+    ${VTK_LIBRARIES}         # Link the VTK libraries to resolve missing symbols
 )
 
-add_executable(test_hazard_metrices test_hazard_metrices.cpp)
 target_link_libraries(test_hazard_metrices 
+    PRIVATE
     ${PCL_LIBRARIES} 
     Open3D::Open3D 
     octomap 
     gtest 
     gtest_main
-    GL                     # -lGL
-    GLU                    # -lGLU
-    glfw                   # -lglfw
-    GLEW                   # -lGLEW
-    assimp                 # -lassimp
-    jsoncpp               # -ljsoncpp
-    jpeg                   # -ljpeg
-    png                    # -lpng
-    z                      # -lz
-    pthread                # -lpthread
+    GL                       # -lGL
+    GLU                      # -lGLU
+    glfw                     # -lglfw
+    GLEW                     # -lGLEW
+    assimp                   # -lassimp
+    jsoncpp                 # -ljsoncpp
+    jpeg                     # -ljpeg
+    png                      # -lpng
+    z                        # -lz
+    pthread                  # -lpthread
+    ${VTK_LIBRARIES}         # Link VTK libraries here as well
 )
 
 # Link OpenMP last to ensure correct symbol resolution

--- a/lib/hazard_metrices/hazard_metrices.h
+++ b/lib/hazard_metrices/hazard_metrices.h
@@ -161,7 +161,7 @@ PCLResult PrincipleComponentAnalysis(const std::string& file_path,
     // (Optional) Downsample the cloud.
     downsamplePointCloudPCL<PointT>(cloud, result.downsampled_cloud, voxel_size);
     // If no downsampling is desired, simply use the loaded cloud.
-    result.downsampled_cloud = cloud;
+    //result.downsampled_cloud = cloud;
 
     // Build a kd-tree for neighborhood searches.
     pcl::KdTreeFLANN<PointT> tree;

--- a/lib/hazard_metrices/hazard_metrices.h
+++ b/lib/hazard_metrices/hazard_metrices.h
@@ -86,18 +86,20 @@ struct PCLResult {
   PointCloudT::Ptr downsampled_cloud;
   PointCloudT::Ptr inlier_cloud;
   PointCloudT::Ptr outlier_cloud;
+  std::string pcl_method;
 };
 //=======================================STRUCT TO HOLD OPEN3D RESULT==========================================
 struct OPEN3DResult {
     std::shared_ptr<open3d::geometry::PointCloud> inlier_cloud;
     std::shared_ptr<open3d::geometry::PointCloud> outlier_cloud;
     std::shared_ptr<open3d::geometry::PointCloud> downsampled_cloud;
+    std::string open3d_method;
 };
 //====================================== VISUALIZATION PCL ====================================================
 inline void visualizePCL(const PCLResult &result)
 {
   // Create a visualizer object.
-  pcl::visualization::PCLVisualizer::Ptr viewer(new pcl::visualization::PCLVisualizer("PointCloud Viewer"));
+  pcl::visualization::PCLVisualizer::Ptr viewer(new pcl::visualization::PCLVisualizer(result.pcl_method + " PCL RESULT "));
   viewer->setBackgroundColor(1.0, 1.0, 1.0);
 
   // Add the outlier cloud (red) if available.
@@ -142,7 +144,7 @@ inline void VisualizeOPEN3D(const OPEN3DResult& result) {
     geometries.push_back(outlier_cloud);
 
     // Launch the visualizer.
-    open3d::visualization::DrawGeometries(geometries, "RANSAC Segmentation Result", 800, 600);
+    open3d::visualization::DrawGeometries(geometries, result.open3d_method + " OPEN3D  Result", 800, 600);
 }
 
 //================================================================================================================================================
@@ -229,7 +231,7 @@ PCLResult computeNormalsAndClassifyPoints(const std::string& file_path,
 
     std::cout << "Inliers (slope ≤ " << slope_threshold << "°): " << result.inlier_cloud->size() << std::endl;
     std::cout << "Outliers (slope > " << slope_threshold << "°): " << result.outlier_cloud->size() << std::endl;
-
+    result.pcl_method="PCA";
     return result;
 }
 
@@ -301,7 +303,7 @@ inline OPEN3DResult RansacPlaneSegmentation(
 
     std::cout << "Inlier cloud has " << result.inlier_cloud->points_.size() << " points." << std::endl;
     std::cout << "Outlier cloud has " << result.outlier_cloud->points_.size() << " points." << std::endl;
-
+    result.open3d_method ="RANSAC";
     return result;
 }
 
@@ -371,7 +373,7 @@ inline PCLResult performRANSAC(const std::string &file_path,
   // Extract outliers (points not on the plane)
   extract.setNegative(true);
   extract.filter(*result.outlier_cloud);
-
+  result.pcl_method="RANSAC";
   return result;
 }
 
@@ -432,7 +434,7 @@ inline PCLResult performPROSAC(const std::string &file_path,
   // Extract outliers (points not on the plane)
   extract.setNegative(true);
   extract.filter(*result.outlier_cloud);
-
+  result.pcl_method="PROSAC";
   return result;
 }
 
@@ -525,6 +527,7 @@ inline OPEN3DResult LeastSquaresPlaneFitting(const std::string &file_path, doubl
               << outliers->points_.size() << " outliers." << std::endl;
     result.inlier_cloud = inliers;
     result.outlier_cloud = outliers;
+    result.open3d_method ="LEAST SQUARE PLANE FITTING";
     return result;
     //return std::make_tuple(inliers, outliers);
 }
@@ -586,7 +589,7 @@ inline PCLResult performLMEDS(const std::string &file_path,
   // Extract outliers (points not on the plane)
   extract.setNegative(true);
   extract.filter(*result.outlier_cloud);
-
+  result.pcl_method="LMEDS";
   return result;
 }
 
@@ -809,6 +812,7 @@ inline PCLResult regionGrowingSegmentation(
   PCLResult result;
   result.inlier_cloud = inliers_cloud;
   result.outlier_cloud = outliers_cloud;
+  result.pcl_method="REGION GROWING SEGMENTATION";
   return result;
 }
 

--- a/lib/hazard_metrices/hazard_metrices.h
+++ b/lib/hazard_metrices/hazard_metrices.h
@@ -1,0 +1,815 @@
+#ifndef HAZARD_METRICES_H
+#define HAZARD_METRICES_H
+
+#include <iostream>
+#include <string>
+#include <sstream>
+#include <thread>
+#include <chrono>
+#include <cmath>
+#include <limits>
+
+#include <pcl/io/pcd_io.h>
+#include <pcl/point_types.h>
+#include <pcl/kdtree/kdtree_flann.h>
+#include <pcl/common/centroid.h>
+#include <pcl/common/eigen.h>
+#include <pcl/filters/voxel_grid.h>
+#include <pcl/visualization/pcl_visualizer.h>
+
+#include <pcl/sample_consensus/method_types.h>
+#include <pcl/sample_consensus/model_types.h>
+#include <pcl/segmentation/sac_segmentation.h>
+#include <pcl/sample_consensus/lmeds.h>  
+
+#include <pcl/filters/extract_indices.h>
+
+#include <pcl/surface/mls.h>
+#include <pcl/features/integral_image_normal.h>
+
+#include <pcl/features/normal_3d.h>
+#include <pcl/segmentation/region_growing.h>
+#include <pcl/common/common.h> 
+
+#include <eigen3/Eigen/Dense>
+#include <open3d/Open3D.h>
+
+using PointT = pcl::PointXYZ;
+using PointCloudT = pcl::PointCloud<PointT>;
+
+
+//#include <pcl/common/pca.h>
+
+//----------------------------------------------------------------------------
+// Function: computeNormalsAndClassifyPoints
+// Computes normals using PCA on local neighborhoods, calculates slopes,
+// and classifies points into inliers (slope ≤ threshold) and outliers (slope > threshold).
+//----------------------------------------------------------------------------
+
+inline std::shared_ptr<open3d::geometry::PointCloud> downSamplePointCloudOpen3d(
+    const std::shared_ptr<open3d::geometry::PointCloud>& pcd, double voxel_size) {
+    
+    auto downsampled_pcd = pcd->VoxelDownSample(voxel_size);
+    std::cout << "Downsampled point cloud has " 
+              << downsampled_pcd->points_.size() << " points." << std::endl;
+    return downsampled_pcd;
+}
+
+template <typename PointT>
+void downsamplePointCloudPCL(typename pcl::PointCloud<PointT>::ConstPtr input_cloud,
+                          typename pcl::PointCloud<PointT>::Ptr output_cloud,
+                          float voxel_size = 0.05f)  // Default voxel size: 5 cm
+{
+    pcl::VoxelGrid<PointT> voxel_grid;
+    voxel_grid.setInputCloud(input_cloud);
+    voxel_grid.setLeafSize(voxel_size, voxel_size, voxel_size);  // Set voxel size
+    voxel_grid.filter(*output_cloud);
+
+    std::cout << "Downsampled point cloud: " << output_cloud->size() << " points." << std::endl;
+}
+
+
+
+// Helper function to downsample the point cloud.
+template <typename PointT>
+inline void downsamplePointCloudPCL(const typename pcl::PointCloud<PointT>::Ptr &input_cloud,
+                                     typename pcl::PointCloud<PointT>::Ptr &output_cloud,
+                                     float leaf_size)
+{
+    pcl::VoxelGrid<PointT> vg;
+    vg.setInputCloud(input_cloud);
+    vg.setLeafSize(leaf_size, leaf_size, leaf_size);
+    vg.filter(*output_cloud);
+}
+//======================================STRUCT TO HOLD PCL RESULT ============================================
+struct PCLResult {
+  PointCloudT::Ptr downsampled_cloud;
+  PointCloudT::Ptr inlier_cloud;
+  PointCloudT::Ptr outlier_cloud;
+};
+//=======================================STRUCT TO HOLD OPEN3D RESULT==========================================
+struct OPEN3DResult {
+    std::shared_ptr<open3d::geometry::PointCloud> inlier_cloud;
+    std::shared_ptr<open3d::geometry::PointCloud> outlier_cloud;
+    std::shared_ptr<open3d::geometry::PointCloud> downsampled_cloud;
+};
+//====================================== VISUALIZATION PCL ====================================================
+inline void visualizePCL(const PCLResult &result)
+{
+  // Create a visualizer object.
+  pcl::visualization::PCLVisualizer::Ptr viewer(new pcl::visualization::PCLVisualizer("PointCloud Viewer"));
+  viewer->setBackgroundColor(1.0, 1.0, 1.0);
+
+  // Add the outlier cloud (red) if available.
+  if (result.outlier_cloud && !result.outlier_cloud->empty())
+  {
+    pcl::visualization::PointCloudColorHandlerCustom<pcl::PointXYZ> outlierColorHandler(result.outlier_cloud, 255, 0, 0);
+    viewer->addPointCloud<pcl::PointXYZ>(result.outlier_cloud, outlierColorHandler, "non_plane_cloud");
+    viewer->setPointCloudRenderingProperties(pcl::visualization::PCL_VISUALIZER_POINT_SIZE, 2, "non_plane_cloud");
+  }
+  
+  // Add the inlier cloud (green) if available.
+  if (result.inlier_cloud && !result.inlier_cloud->empty())
+  {
+    pcl::visualization::PointCloudColorHandlerCustom<pcl::PointXYZ> inlierColorHandler(result.inlier_cloud, 0, 255, 0);
+    viewer->addPointCloud<pcl::PointXYZ>(result.inlier_cloud, inlierColorHandler, "plane_cloud");
+    viewer->setPointCloudRenderingProperties(pcl::visualization::PCL_VISUALIZER_POINT_SIZE, 3, "plane_cloud");
+  }
+  
+  // Main loop to keep the visualizer window open.
+  while (!viewer->wasStopped())
+  {
+    viewer->spinOnce(100);
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+  }
+}
+
+//==========================================VISULAIZE OPEN3D=====================================================================================
+
+// Visualization function for RANSAC plane segmentation result.
+inline void VisualizeOPEN3D(const OPEN3DResult& result) {
+    // Clone the point clouds to avoid modifying the originals.
+    auto inlier_cloud = std::make_shared<open3d::geometry::PointCloud>(*result.inlier_cloud);
+    auto outlier_cloud = std::make_shared<open3d::geometry::PointCloud>(*result.outlier_cloud);
+
+    // Set the colors: inliers to green and outliers to red.
+    inlier_cloud->PaintUniformColor(Eigen::Vector3d(0.0, 1.0, 0.0)); // Green
+    outlier_cloud->PaintUniformColor(Eigen::Vector3d(1.0, 0.0, 0.0)); // Red
+
+    // Combine the point clouds into a vector for visualization.
+    std::vector<std::shared_ptr<const open3d::geometry::Geometry>> geometries;
+    geometries.push_back(inlier_cloud);
+    geometries.push_back(outlier_cloud);
+
+    // Launch the visualizer.
+    open3d::visualization::DrawGeometries(geometries, "RANSAC Segmentation Result", 800, 600);
+}
+
+//================================================================================================================================================
+
+
+template <typename PointT>
+PCLResult computeNormalsAndClassifyPoints(const std::string& file_path,
+                                          pcl::PointCloud<pcl::Normal>::Ptr normals,
+                                          float voxel_size = 0.45f,
+                                          float slope_threshold = 20.0f,  // degrees
+                                          int k = 10)  // k-nearest neighbors
+{
+    PCLResult result;
+    
+    // Allocate the result point clouds.
+    result.inlier_cloud = pcl::make_shared<typename pcl::PointCloud<PointT>>();
+    result.outlier_cloud = pcl::make_shared<typename pcl::PointCloud<PointT>>();
+    result.downsampled_cloud = pcl::make_shared<typename pcl::PointCloud<PointT>>();
+
+    // Load the original point cloud.
+    typename pcl::PointCloud<PointT>::Ptr cloud(new pcl::PointCloud<PointT>);
+    if (pcl::io::loadPCDFile<PointT>(file_path, *cloud) == -1) {
+        PCL_ERROR("Couldn't read file %s\n", file_path.c_str());
+        return result;
+    }
+    std::cout << "[Block 1] Loaded " << cloud->size() << " points from " << file_path << std::endl;
+
+    // (Optional) Downsample the cloud. If you wish to downsample, uncomment and adjust the following:
+    downsamplePointCloudPCL<PointT>(cloud, result.downsampled_cloud, voxel_size);
+    //std::cout << "Pointcloud downsampled " << result.downsampled_cloud->size();
+    // For now, we'll assume no downsampling is applied and just use the loaded cloud.
+    result.downsampled_cloud = cloud;
+
+    // Build a kd-tree for neighborhood searches.
+    pcl::KdTreeFLANN<PointT> tree;
+    tree.setInputCloud(cloud);
+
+    // Prepare the normals cloud.
+    normals->points.resize(cloud->points.size());
+    normals->width    = cloud->width;
+    normals->height   = cloud->height;
+    normals->is_dense = cloud->is_dense;
+
+    std::vector<int> neighbor_indices(k);
+    std::vector<float> sqr_distances(k);
+
+    // Process each point in the cloud.
+    for (size_t i = 0; i < cloud->points.size(); i++)
+    {
+        if (tree.nearestKSearch(cloud->points[i], k, neighbor_indices, sqr_distances) > 0)
+        {
+            // Compute local centroid and covariance.
+            Eigen::Vector4f local_centroid;
+            pcl::compute3DCentroid(*cloud, neighbor_indices, local_centroid);
+
+            Eigen::Matrix3f covariance;
+            pcl::computeCovarianceMatrixNormalized(*cloud, neighbor_indices, local_centroid, covariance);
+
+            // The eigenvector corresponding to the smallest eigenvalue is the surface normal.
+            Eigen::SelfAdjointEigenSolver<Eigen::Matrix3f> solver(covariance);
+            Eigen::Vector3f normal = solver.eigenvectors().col(0);
+
+            normals->points[i].normal_x = normal.x();
+            normals->points[i].normal_y = normal.y();
+            normals->points[i].normal_z = normal.z();
+
+            // Calculate slope as the angle with vertical (0,0,1).
+            float dot_product = std::fabs(normal.dot(Eigen::Vector3f(0.0f, 0.0f, 1.0f)));
+            float slope = std::acos(dot_product) * 180.0f / static_cast<float>(M_PI);
+
+            // Classify point based on slope threshold.
+            if (slope <= slope_threshold)
+                result.inlier_cloud->push_back(cloud->points[i]);  // Safe landing point.
+            else
+                result.outlier_cloud->push_back(cloud->points[i]);   // Unsafe point.
+        }
+        else
+        {
+            normals->points[i].normal_x = std::numeric_limits<float>::quiet_NaN();
+            normals->points[i].normal_y = std::numeric_limits<float>::quiet_NaN();
+            normals->points[i].normal_z = std::numeric_limits<float>::quiet_NaN();
+        }
+    }
+
+    std::cout << "Inliers (slope ≤ " << slope_threshold << "°): " << result.inlier_cloud->size() << std::endl;
+    std::cout << "Outliers (slope > " << slope_threshold << "°): " << result.outlier_cloud->size() << std::endl;
+
+    return result;
+}
+
+//=========================================================================================================================
+
+
+// RANSAC plane segmentation function.
+// It loads a point cloud from file, downsamples it internally,
+// performs RANSAC plane segmentation, and splits the downsampled cloud
+// into inlier and outlier point clouds.
+inline OPEN3DResult RansacPlaneSegmentation(
+    const std::string& file_path,
+    double voxel_size,
+    double distance_threshold,
+    int ransac_n,
+    int num_iterations)
+{
+    OPEN3DResult result;
+
+    // Load the point cloud from file.
+    auto pcd = std::make_shared<open3d::geometry::PointCloud>();
+    if (!open3d::io::ReadPointCloud(file_path, *pcd)) {
+        std::cerr << "Error: Unable to read point cloud from " << file_path << std::endl;
+        return result;  // Return empty result on error.
+    }
+    std::cout << "Loaded point cloud with " << pcd->points_.size() << " points." << std::endl;
+
+    // Downsample the point cloud.
+    result.downsampled_cloud = downSamplePointCloudOpen3d(pcd, voxel_size);
+    std::cout << "Downsampled point cloud now has " << result.downsampled_cloud->points_.size() << " points." << std::endl;
+
+    // Ensure the downsampled point cloud has color information.
+    if (!result.downsampled_cloud->HasColors()) {
+        result.downsampled_cloud->colors_.resize(result.downsampled_cloud->points_.size(), Eigen::Vector3d(1, 1, 1));
+    }
+
+    // Perform RANSAC plane segmentation.
+    // 'SegmentPlane' returns a pair: the plane model and the vector of inlier indices.
+    double probability = 0.9999;
+    Eigen::Vector4d plane_model;
+    auto [plane, indices] = result.downsampled_cloud->SegmentPlane(distance_threshold, ransac_n, num_iterations, probability);
+    plane_model = plane;
+    std::cout << "Plane model: " << plane_model.transpose() << std::endl;
+    std::cout << "Found " << indices.size() << " inliers for the plane." << std::endl;
+
+    // Create new point clouds for inliers and outliers.
+    result.inlier_cloud = std::make_shared<open3d::geometry::PointCloud>();
+    result.outlier_cloud = std::make_shared<open3d::geometry::PointCloud>();
+  
+
+    // Build a set of inlier indices for quick lookup.
+    std::unordered_set<size_t> inlier_set(indices.begin(), indices.end());
+    size_t total_points = result.downsampled_cloud->points_.size();
+
+    // Loop over each point in the downsampled point cloud and split the points.
+    for (size_t i = 0; i < total_points; ++i) {
+        if (inlier_set.find(i) != inlier_set.end()) {
+            result.inlier_cloud->points_.push_back(result.downsampled_cloud->points_[i]);
+            if (!result.downsampled_cloud->colors_.empty()) {
+                result.inlier_cloud->colors_.push_back(result.downsampled_cloud->colors_[i]);
+            }
+        } else {
+            result.outlier_cloud->points_.push_back(result.downsampled_cloud->points_[i]);
+            if (!result.downsampled_cloud->colors_.empty()) {
+                result.outlier_cloud->colors_.push_back(result.downsampled_cloud->colors_[i]);
+            }
+        }
+    }
+
+    std::cout << "Inlier cloud has " << result.inlier_cloud->points_.size() << " points." << std::endl;
+    std::cout << "Outlier cloud has " << result.outlier_cloud->points_.size() << " points." << std::endl;
+
+    return result;
+}
+
+
+
+
+
+// Function to perform RANSAC segmentation.
+// Parameters:
+// - filePath: Path to the input PCD file.
+// - voxelSize: Leaf size for the voxel grid downsampling.
+// - distanceThreshold: Maximum distance from the plane for a point to be considered an inlier.
+// - maxIterations: Maximum number of iterations for the RANSAC algorithm.
+inline PCLResult performRANSAC(const std::string &file_path,
+                           float voxelSize = 0.05f,
+                           float distanceThreshold = 0.02f,
+                           int maxIterations = 100)
+{
+  // Initialize the result structure with new point clouds
+  PCLResult result;
+  result.downsampled_cloud = pcl::make_shared<PointCloudT>();
+  result.inlier_cloud = pcl::make_shared<PointCloudT>();
+  result.outlier_cloud = pcl::make_shared<PointCloudT>();
+
+  // Load the point cloud from file
+  PointCloudT::Ptr cloud(new PointCloudT);
+  if (pcl::io::loadPCDFile<PointT>(file_path, *cloud) == -1)
+  {
+    PCL_ERROR("Couldn't read file %s \n", file_path.c_str());
+    return result;
+  }
+  std::cout << "Loaded point cloud with " << cloud->points.size() << " points." << std::endl;
+
+  // Use the provided downsampling function to downsample the cloud
+  downsamplePointCloudPCL<PointT>(cloud, result.downsampled_cloud, voxelSize);
+  // If detecting a table or ground plane → SACMODEL_PLANE + SAC_RANSAC
+  // If extracting pipes or poles → SACMODEL_CYLINDER + SAC_RANSAC
+  // If detecting objects with circular features → SACMODEL_CIRCLE3D + SAC_LMEDS
+  // If handling large noisy datasets → SACMODEL_PLANE + SAC_RRANSAC
+  // If prioritizing accuracy over speed → SACMODEL_PLANE + SAC_MLESAC
+  // Extract inliers (the plane) from the cloud
+  // Set up RANSAC segmentation for a plane model
+  pcl::SACSegmentation<PointT> seg;
+  pcl::PointIndices::Ptr inliers(new pcl::PointIndices);
+  pcl::ModelCoefficients::Ptr coefficients(new pcl::ModelCoefficients);
+  seg.setOptimizeCoefficients(true);
+  seg.setModelType(pcl::SACMODEL_PLANE);
+  seg.setMethodType(pcl::SAC_RANSAC);
+  seg.setMaxIterations(maxIterations);
+  seg.setDistanceThreshold(distanceThreshold);
+  seg.setInputCloud(result.downsampled_cloud);
+  seg.segment(*inliers, *coefficients);
+
+  if (inliers->indices.empty())
+  {
+    std::cerr << "Could not estimate a planar model for the given dataset." << std::endl;
+    return result;
+  }
+  std::cout << "RANSAC found " << inliers->indices.size() << " inliers." << std::endl;
+
+  pcl::ExtractIndices<PointT> extract;
+  extract.setInputCloud(result.downsampled_cloud);
+  extract.setIndices(inliers);
+  extract.setNegative(false);
+  extract.filter(*result.inlier_cloud);
+
+  // Extract outliers (points not on the plane)
+  extract.setNegative(true);
+  extract.filter(*result.outlier_cloud);
+
+  return result;
+}
+
+
+inline PCLResult performPROSAC(const std::string &file_path,
+                           float voxelSize = 0.05f,
+                           float distanceThreshold = 0.02f,
+                           int maxIterations = 100)
+{
+  // Initialize the result structure with new point clouds
+  PCLResult result;
+  result.downsampled_cloud = pcl::make_shared<PointCloudT>();
+  result.inlier_cloud = pcl::make_shared<PointCloudT>();
+  result.outlier_cloud = pcl::make_shared<PointCloudT>();
+
+  // Load the point cloud from file
+  PointCloudT::Ptr cloud(new PointCloudT);
+  if (pcl::io::loadPCDFile<PointT>(file_path, *cloud) == -1)
+  {
+    PCL_ERROR("Couldn't read file %s \n", file_path.c_str());
+    return result;
+  }
+  std::cout << "Loaded point cloud with " << cloud->points.size() << " points." << std::endl;
+
+  // Use the provided downsampling function to downsample the cloud
+  downsamplePointCloudPCL<PointT>(cloud, result.downsampled_cloud, voxelSize);
+  // If detecting a table or ground plane → SACMODEL_PLANE + SAC_RANSAC
+  // If extracting pipes or poles → SACMODEL_CYLINDER + SAC_RANSAC
+  // If detecting objects with circular features → SACMODEL_CIRCLE3D + SAC_LMEDS
+  // If handling large noisy datasets → SACMODEL_PLANE + SAC_RRANSAC
+  // If prioritizing accuracy over speed → SACMODEL_PLANE + SAC_MLESAC
+  // Extract inliers (the plane) from the cloud
+  // Set up PROSAC segmentation for a plane model
+  pcl::SACSegmentation<PointT> seg;
+  pcl::PointIndices::Ptr inliers(new pcl::PointIndices);
+  pcl::ModelCoefficients::Ptr coefficients(new pcl::ModelCoefficients);
+  seg.setOptimizeCoefficients(true);
+  seg.setModelType(pcl::SACMODEL_PLANE);
+  seg.setMethodType(pcl::SAC_PROSAC);
+  seg.setMaxIterations(maxIterations);
+  seg.setDistanceThreshold(distanceThreshold);
+  seg.setInputCloud(result.downsampled_cloud);
+  seg.segment(*inliers, *coefficients);
+
+  if (inliers->indices.empty())
+  {
+    std::cerr << "Could not estimate a planar model for the given dataset." << std::endl;
+    return result;
+  }
+  std::cout << "PROSAC found " << inliers->indices.size() << " inliers." << std::endl;
+
+  pcl::ExtractIndices<PointT> extract;
+  extract.setInputCloud(result.downsampled_cloud);
+  extract.setIndices(inliers);
+  extract.setNegative(false);
+  extract.filter(*result.inlier_cloud);
+
+  // Extract outliers (points not on the plane)
+  extract.setNegative(true);
+  extract.filter(*result.outlier_cloud);
+
+  return result;
+}
+
+
+inline std::tuple<Eigen::Vector3d, std::shared_ptr<open3d::geometry::PointCloud>>
+RansacPlaneAndComputeCentroid(
+    const std::string& file_path,
+    double voxel_size,
+    double distance_threshold,
+    int ransac_n,
+    int num_iterations) {
+
+    // Perform RANSAC segmentation to detect the ground plane.
+    OPEN3DResult result = RansacPlaneSegmentation(file_path, voxel_size, distance_threshold,
+                                                  ransac_n, num_iterations);
+
+    Eigen::Vector3d centroid(0, 0, 0);
+
+    // Check if the inlier point cloud is empty.
+    if (result.inlier_cloud->points_.empty()) {
+        std::cerr << "Warning: No inlier points provided. Returning zero centroid." << std::endl;
+        return std::make_tuple(centroid,result.downsampled_cloud);
+    }
+
+    // Iterate over the inlier points (stored in the points_ vector) to compute the centroid.
+    for (const auto &pt : result.inlier_cloud->points_) {
+        centroid += pt;
+    }
+    centroid /= static_cast<double>(result.inlier_cloud->points_.size());
+
+    return std::make_tuple(centroid,result.downsampled_cloud);
+}
+
+inline OPEN3DResult LeastSquaresPlaneFitting(const std::string &file_path, double voxel_size, double distance_threshold) {
+    // Load the point cloud from file.
+
+    OPEN3DResult result;
+    int ransac_n =3;
+    int num_iterations = 1000;
+    auto [centroid,downsampled_pcd] = RansacPlaneAndComputeCentroid(file_path, voxel_size, distance_threshold, ransac_n, num_iterations);
+
+    // auto pcd = open3d::io::CreatePointCloudFromFile(file_path);
+    // if (!pcd || pcd->points_.empty()) {
+    //     throw std::runtime_error("Failed to load point cloud from file: " + file_path);
+    // }
+    // std::cout << "Loaded point cloud with " << pcd->points_.size() << " points." << std::endl;
+
+    // // // Downsample the point cloud using a voxel grid.
+    // auto downsampled_pcd = pcd->VoxelDownSample(voxel_size);
+    // std::cout << "Downsampled point cloud to " << downsampled_pcd->points_.size() << " points." << std::endl;
+
+    // Compute the covariance matrix.
+    Eigen::Matrix3d covariance = Eigen::Matrix3d::Zero();
+    for (const auto &pt : downsampled_pcd->points_) {
+        Eigen::Vector3d diff = pt - centroid;
+        covariance += diff * diff.transpose();
+    }
+
+    // Compute the eigen decomposition of the covariance matrix.
+    Eigen::SelfAdjointEigenSolver<Eigen::Matrix3d> eigen_solver(covariance);
+    if (eigen_solver.info() != Eigen::Success) {
+        throw std::runtime_error("Eigen decomposition failed.");
+    }
+    // The eigenvector corresponding to the smallest eigenvalue is the plane normal.
+    Eigen::Vector3d normal = eigen_solver.eigenvectors().col(0);
+    normal.normalize();
+
+    // Compute the plane equation: n.dot(x) + d = 0.
+    double d = -normal.dot(centroid);
+    std::cout << "Fitted plane: normal = " << normal.transpose() << ", d = " << d << std::endl;
+
+    // Separate points into inliers and outliers based on distance from the plane.
+    auto inliers = std::make_shared<open3d::geometry::PointCloud>();
+    auto outliers = std::make_shared<open3d::geometry::PointCloud>();
+
+    for (const auto &pt : downsampled_pcd->points_) {
+        double distance = std::fabs(normal.dot(pt) + d);
+        if (distance < distance_threshold) {
+            inliers->points_.push_back(pt);
+            // Color inliers green.
+            inliers->colors_.push_back({0.0, 1.0, 0.0});
+        } else {
+            outliers->points_.push_back(pt);
+            // Color outliers red.
+            outliers->colors_.push_back({1.0, 0.0, 0.0});
+        }
+    }
+
+    std::cout << "Found " << inliers->points_.size() << " inliers and "
+              << outliers->points_.size() << " outliers." << std::endl;
+    result.inlier_cloud = inliers;
+    result.outlier_cloud = outliers;
+    return result;
+    //return std::make_tuple(inliers, outliers);
+}
+
+
+inline PCLResult performLMEDS(const std::string &file_path,
+                           float voxelSize = 0.05f,
+                           float distanceThreshold = 0.02f,
+                           int maxIterations = 100)
+{
+  // Initialize the result structure with new point clouds
+  PCLResult result;
+  result.downsampled_cloud = pcl::make_shared<PointCloudT>();
+  result.inlier_cloud = pcl::make_shared<PointCloudT>();
+  result.outlier_cloud = pcl::make_shared<PointCloudT>();
+
+  // Load the point cloud from file
+  PointCloudT::Ptr cloud(new PointCloudT);
+  if (pcl::io::loadPCDFile<PointT>(file_path, *cloud) == -1)
+  {
+    PCL_ERROR("Couldn't read file %s \n", file_path.c_str());
+    return result;
+  }
+  std::cout << "Loaded point cloud with " << cloud->points.size() << " points." << std::endl;
+
+  // Use the provided downsampling function to downsample the cloud
+  downsamplePointCloudPCL<PointT>(cloud, result.downsampled_cloud, voxelSize);
+  // If detecting a table or ground plane → SACMODEL_PLANE + SAC_RANSAC
+  // If extracting pipes or poles → SACMODEL_CYLINDER + SAC_RANSAC
+  // If detecting objects with circular features → SACMODEL_CIRCLE3D + SAC_LMEDS
+  // If handling large noisy datasets → SACMODEL_PLANE + SAC_RRANSAC
+  // If prioritizing accuracy over speed → SACMODEL_PLANE + SAC_MLESAC
+  // Extract inliers (the plane) from the cloud
+  // Set up LMEDS segmentation for a plane model
+  pcl::SACSegmentation<PointT> seg;
+  pcl::PointIndices::Ptr inliers(new pcl::PointIndices);
+  pcl::ModelCoefficients::Ptr coefficients(new pcl::ModelCoefficients);
+  seg.setOptimizeCoefficients(true);
+  seg.setModelType(pcl::SACMODEL_PLANE);
+  seg.setMethodType(pcl::SAC_LMEDS);
+  seg.setMaxIterations(maxIterations);
+  seg.setDistanceThreshold(distanceThreshold);
+  seg.setInputCloud(result.downsampled_cloud);
+  seg.segment(*inliers, *coefficients);
+
+  if (inliers->indices.empty())
+  {
+    std::cerr << "Could not estimate a planar model for the given dataset." << std::endl;
+    return result;
+  }
+  std::cout << "LMEDS found " << inliers->indices.size() << " inliers." << std::endl;
+
+  pcl::ExtractIndices<PointT> extract;
+  extract.setInputCloud(result.downsampled_cloud);
+  extract.setIndices(inliers);
+  extract.setNegative(false);
+  extract.filter(*result.inlier_cloud);
+
+  // Extract outliers (points not on the plane)
+  extract.setNegative(true);
+  extract.filter(*result.outlier_cloud);
+
+  return result;
+}
+
+
+// Function to compute normals using the Average 3D Gradient method,
+// classify points based on a slope threshold, and return inliers and outliers.
+// std::pair<pcl::PointCloud<pcl::PointXYZRGB>::Ptr, pcl::PointCloud<pcl::PointXYZRGB>::Ptr>
+// computeNormalsUsingAverage3DGradient(const pcl::PointCloud<pcl::PointXYZ>::Ptr &cloud,
+//                                       float slope_threshold = 20.0f,
+//                                       float max_depth_change_factor = 0.02f,
+//                                       float normal_smoothing_size = 10.0f)
+// {
+//     // Container for computed normals.
+//     pcl::PointCloud<pcl::Normal>::Ptr normals(new pcl::PointCloud<pcl::Normal>);
+
+//     // Set up the integral image normal estimation (using the AVERAGE_3D_GRADIENT method).
+//     pcl::IntegralImageNormalEstimation<pcl::PointXYZ, pcl::Normal> ne;
+//     ne.setNormalEstimationMethod(
+//         ne.AVERAGE_3D_GRADIENT);
+//     ne.setMaxDepthChangeFactor(max_depth_change_factor);
+//     ne.setNormalSmoothingSize(normal_smoothing_size);
+//     ne.setInputCloud(cloud);
+//     ne.compute(*normals);
+
+//     // Containers for inliers (green) and outliers (red).
+//     pcl::PointCloud<pcl::PointXYZRGB>::Ptr inliers(new pcl::PointCloud<pcl::PointXYZRGB>);
+//     pcl::PointCloud<pcl::PointXYZRGB>::Ptr outliers(new pcl::PointCloud<pcl::PointXYZRGB>);
+
+//     // For each point, compute the angle between its normal and the vertical vector (0, 0, 1).
+//     for (size_t i = 0; i < cloud->points.size(); i++)
+//     {
+//         const pcl::PointXYZ &pt = cloud->points[i];
+//         const pcl::Normal &n = normals->points[i];
+
+//         Eigen::Vector3f normal(n.normal_x, n.normal_y, n.normal_z);
+//         float dot = std::fabs(normal.dot(Eigen::Vector3f(0.0f, 0.0f, 1.0f)));
+//         float angle = std::acos(dot) * 180.0f / static_cast<float>(M_PI);
+
+//         // Create a colored point with the original coordinates.
+//         pcl::PointXYZRGB colored_point;
+//         colored_point.x = pt.x;
+//         colored_point.y = pt.y;
+//         colored_point.z = pt.z;
+
+//         if (angle <= slope_threshold)
+//         {
+//             // Inlier (slope is below the threshold): color it green.
+//             colored_point.r = 0;
+//             colored_point.g = 255;
+//             colored_point.b = 0;
+//             inliers->push_back(colored_point);
+//         }
+//         else
+//         {
+//             // Outlier (slope exceeds the threshold): color it red.
+//             colored_point.r = 255;
+//             colored_point.g = 0;
+//             colored_point.b = 0;
+//             outliers->push_back(colored_point);
+//         }
+//     }
+
+//     return std::make_pair(inliers, outliers);
+// }
+
+// // Function to visualize the classified point clouds.
+// void visualizeClassifiedCloud(const pcl::PointCloud<pcl::PointXYZRGB>::Ptr &inliers,
+//                               const pcl::PointCloud<pcl::PointXYZRGB>::Ptr &outliers)
+// {
+//     pcl::visualization::PCLVisualizer viewer("Classified Cloud Viewer");
+//     viewer.setBackgroundColor(0.0, 0.0, 0.0);
+
+//     // Add inliers (green) to the viewer.
+//     pcl::visualization::PointCloudColorHandlerRGBField<pcl::PointXYZRGB> inlier_color(inliers);
+//     viewer.addPointCloud<pcl::PointXYZRGB>(inliers, inlier_color, "inliers");
+//     viewer.setPointCloudRenderingProperties(pcl::visualization::PCL_VISUALIZER_POINT_SIZE, 2, "inliers");
+
+//     // Add outliers (red) to the viewer.
+//     pcl::visualization::PointCloudColorHandlerRGBField<pcl::PointXYZRGB> outlier_color(outliers);
+//     viewer.addPointCloud<pcl::PointXYZRGB>(outliers, outlier_color, "outliers");
+//     viewer.setPointCloudRenderingProperties(pcl::visualization::PCL_VISUALIZER_POINT_SIZE, 2, "outliers");
+
+//     while (!viewer.wasStopped())
+//     {
+//         viewer.spinOnce();
+//     }
+// }
+
+
+// Region growing segmentation function.
+// Parameters:
+//   file_path      : path to the PCD file (modify this string as needed)
+//   voxel_leaf    : voxel grid leaf size for downsampling
+// Returns:
+//   A RegionGrowingSegmentationResult structure containing the downsampled cloud,
+//   the inliers (points in any region), and the outliers.
+inline PCLResult regionGrowingSegmentation(
+    const std::string &file_path,
+    float voxel_leaf,
+    int min_cluster_size = 50,         // Minimum number of points per cluster.
+    int max_cluster_size = 1000000,      // Maximum number of points per cluster.
+    int number_of_neighbours = 30,       // Nearest neighbours used in region growing.
+    int normal_k_search = 50,            // K nearest neighbors for normal estimation.
+    // Lower the smoothness threshold to about 2° (in radians) so only nearly identical normals join.
+    float smoothness_threshold = 2.0 / 180.0 * M_PI,
+    // Lower the curvature threshold to only allow points with very low curvature (indicative of flat surfaces).
+    float curvature_threshold = 0.9,
+    // Instead of a dot product threshold, provide an angle (in degrees). For instance, 20°.
+    float horizontal_angle_threshold_deg = 10.0f
+)
+{
+
+  // Convert the angle in degrees to a dot product threshold.
+  float horizontal_dot_threshold = std::cos(horizontal_angle_threshold_deg * M_PI / 180.0f);
+
+  // Load the input cloud from file.
+  pcl::PointCloud<pcl::PointXYZ>::Ptr cloud(new pcl::PointCloud<pcl::PointXYZ>);
+  if (pcl::io::loadPCDFile<pcl::PointXYZ>(file_path, *cloud) == -1) {
+    std::cerr << "Failed to load " << file_path << std::endl;
+    exit(EXIT_FAILURE);
+  }
+  std::cout << "Loaded cloud with " << cloud->points.size() << " points." << std::endl;
+
+  // Downsample the cloud using a VoxelGrid filter.
+  pcl::PointCloud<pcl::PointXYZ>::Ptr cloud_downsampled(new pcl::PointCloud<pcl::PointXYZ>);
+  pcl::VoxelGrid<pcl::PointXYZ> voxel;
+  voxel.setInputCloud(cloud);
+  voxel.setLeafSize(voxel_leaf, voxel_leaf, voxel_leaf);
+  voxel.filter(*cloud_downsampled);
+  std::cout << "Downsampled cloud has " << cloud_downsampled->points.size() << " points." << std::endl;
+
+  // Remove any NaN points.
+  std::vector<int> indices;
+  pcl::removeNaNFromPointCloud(*cloud_downsampled, *cloud_downsampled, indices);
+
+  // Estimate normals on the downsampled cloud.
+  pcl::PointCloud<pcl::Normal>::Ptr normals(new pcl::PointCloud<pcl::Normal>);
+  pcl::search::Search<pcl::PointXYZ>::Ptr tree(new pcl::search::KdTree<pcl::PointXYZ>);
+  pcl::NormalEstimation<pcl::PointXYZ, pcl::Normal> normal_estimator;
+  normal_estimator.setSearchMethod(tree);
+  normal_estimator.setInputCloud(cloud_downsampled);
+  normal_estimator.setKSearch(normal_k_search);
+  normal_estimator.compute(*normals);
+
+  // Create indices for valid points.
+  pcl::IndicesPtr valid_indices(new std::vector<int>(indices));
+
+  // Set up the region growing segmentation algorithm.
+  pcl::RegionGrowing<pcl::PointXYZ, pcl::Normal> reg;
+  reg.setMinClusterSize(min_cluster_size);
+  reg.setMaxClusterSize(max_cluster_size);
+  reg.setSearchMethod(tree);
+  reg.setNumberOfNeighbours(number_of_neighbours);
+  reg.setInputCloud(cloud_downsampled);
+  reg.setIndices(valid_indices);
+  reg.setInputNormals(normals);
+  reg.setSmoothnessThreshold(smoothness_threshold);
+  reg.setCurvatureThreshold(curvature_threshold);
+
+  // Extract clusters.
+  std::vector<pcl::PointIndices> clusters;
+  reg.extract(clusters);
+  std::cout << "Found " << clusters.size() << " clusters." << std::endl;
+
+  // Create containers for inliers and outliers.
+  pcl::PointCloud<pcl::PointXYZ>::Ptr inliers_cloud(new pcl::PointCloud<pcl::PointXYZ>);
+  pcl::PointCloud<pcl::PointXYZ>::Ptr outliers_cloud(new pcl::PointCloud<pcl::PointXYZ>);
+
+  // Global vertical axis (assumed here to be the Z-axis).
+  Eigen::Vector3f vertical(0.0f, 0.0f, 1.0f);
+
+  // Process each cluster: compute the average normal and check its alignment with the vertical.
+  for (const auto &cluster : clusters) {
+    Eigen::Vector3f avg_normal(0.0f, 0.0f, 0.0f);
+    for (const auto &idx : cluster.indices) {
+      const auto &n = normals->points[idx];
+      avg_normal += Eigen::Vector3f(n.normal_x, n.normal_y, n.normal_z);
+    }
+    if (!cluster.indices.empty())
+      avg_normal /= static_cast<float>(cluster.indices.size());
+
+    // Normalize the average normal.
+    if (avg_normal.norm() != 0)
+      avg_normal.normalize();
+
+    // Check alignment with vertical.
+    float dot = std::fabs(avg_normal.dot(vertical));
+    if (dot >= horizontal_dot_threshold) {
+      // Cluster is horizontal; add its points to the inliers.
+      for (const auto &idx : cluster.indices) {
+        inliers_cloud->points.push_back(cloud_downsampled->points[idx]);
+      }
+    }
+    else {
+      // Cluster is inclined; add its points to outliers.
+      for (const auto &idx : cluster.indices) {
+        outliers_cloud->points.push_back(cloud_downsampled->points[idx]);
+      }
+    }
+  }
+
+  // Also, add any downsampled points not part of any cluster to the outliers.
+  std::set<int> cluster_indices;
+  for (const auto &cluster : clusters) {
+    for (const auto &idx : cluster.indices) {
+      cluster_indices.insert(idx);
+    }
+  }
+  for (size_t i = 0; i < cloud_downsampled->points.size(); ++i) {
+    if (cluster_indices.find(i) == cluster_indices.end()) {
+      outliers_cloud->points.push_back(cloud_downsampled->points[i]);
+    }
+  }
+
+  // Propagate header information.
+  inliers_cloud->header = cloud_downsampled->header;
+  outliers_cloud->header = cloud_downsampled->header;
+
+  // Return the segmentation result.
+  PCLResult result;
+  result.inlier_cloud = inliers_cloud;
+  result.outlier_cloud = outliers_cloud;
+  return result;
+}
+
+#endif 

--- a/lib/hazard_metrices/main.cpp
+++ b/lib/hazard_metrices/main.cpp
@@ -6,14 +6,6 @@ int main(int argc, char **argv)
     // Input file (same for all blocks)
     static const std::string file_path = "/home/airsim_user/Landing-Assist-Module-LAM/lib/hazard_metrices/test.pcd";
 
-    // pcl::PointCloud<pcl::PointXYZ>::Ptr original_cloud(new pcl::PointCloud<pcl::PointXYZ>);
-    // if (pcl::io::loadPCDFile<pcl::PointXYZ>(file_path, *original_cloud) == -1)
-    // {
-    //     PCL_ERROR("Couldn't read file %s\n", file_path.c_str());
-    //     return -1;
-    // }
-    // std::cout << "Loaded " << original_cloud->size() << " points from " << file_path << std::endl;
-
     //=============================================================================================
     //Block 1: PCA / Normal Estimation / Classification (PCL) TESTED BUT SPEED SHOULD BE INCREASED
     //=============================================================================================
@@ -22,19 +14,16 @@ int main(int argc, char **argv)
         float voxel_size =0.45f;
         float slope_threshold = 10.0f;
         int k =10;
-        pcl::PointCloud<pcl::Normal>::Ptr normals(new pcl::PointCloud<pcl::Normal>);
-
+        
       // Get classification results including the downsampled point cloud.
-        PCLResult classification = computeNormalsAndClassifyPoints<PointT>(file_path,
-                                                                                           normals,
-                                                                                           voxel_size ,
-                                                                                           slope_threshold,  // slope threshold
-                                                                                           k);    // k-nearest neighbors
+        PCLResult result = PrincipleComponentAnalysis<PointT>(file_path,    
+                                                              voxel_size ,
+                                                              slope_threshold,  // slope threshold
+                                                              k);    // k-nearest neighbors
 
       // Use the stored downsampled point cloud in the visualization function.
-        int point_size = 3;
-        visualizePCL(classification);
- 
+        visualizePCL(result);
+
     }
 
     //======================================================

--- a/lib/hazard_metrices/main.cpp
+++ b/lib/hazard_metrices/main.cpp
@@ -116,11 +116,12 @@ int main(int argc, char **argv)
         float voxelSize = 0.1f;
         float neighborRadius = 0.5f;
         float gradientThreshold = 0.15f;
+        float angleThreshold = 10.0f;
 
     
 
         // Call the flatness detection function
-        PCLResult result = Average3DGradient(file_path, voxelSize, neighborRadius, gradientThreshold);
+        PCLResult result = Average3DGradient(file_path, voxelSize, neighborRadius, gradientThreshold, angleThreshold);
         visualizePCL(result,"inlier_cloud");
 
 

--- a/lib/hazard_metrices/main.cpp
+++ b/lib/hazard_metrices/main.cpp
@@ -1,4 +1,5 @@
 #include "hazard_metrices.h"
+#include "pointcloud_preprocessing.h"
 
 int main(int argc, char **argv)
 {
@@ -26,9 +27,9 @@ int main(int argc, char **argv)
 
     }
 
-    // //======================================================
-    // // Block 2: Open3D-Based RANSAC Segmentation TESTED
-    // //======================================================
+    //======================================================
+    // Block 2: Open3D-Based RANSAC Segmentation 
+    //======================================================
 
     {
       // Parameters for downsampling and RANSAC.
@@ -46,9 +47,9 @@ int main(int argc, char **argv)
       VisualizeOPEN3D(result);
     }
 
-    // //======================================================
-    // // Block 3: PCL-Based RANSAC Segmentation TESTED
-    // //======================================================
+    //======================================================
+    // Block 3: PCL-Based RANSAC Segmentation 
+    //======================================================
 
     {
         float voxelSize = 0.15f;
@@ -56,13 +57,13 @@ int main(int argc, char **argv)
         int maxIterations = 1000;
 
         PCLResult result = performRANSAC(file_path, voxelSize, distanceThreshold, maxIterations);
-        visualizePCL(result);
+        visualizePCL(result,"inlier_cloud");
         
     }
 
-    // //======================================================
-    // // Block 4: PROSAC Segmentation (PCL-Based) TESTED
-    // //======================================================
+    //======================================================
+    // Block 4: PROSAC Segmentation (PCL-Based) 
+    //======================================================
 
     {
         float voxel_size =0.15f;
@@ -70,12 +71,12 @@ int main(int argc, char **argv)
         int maxIterations = 200;
 
         PCLResult result = performPROSAC(file_path, voxel_size, distanceThreshold,maxIterations);
-        visualizePCL(result);
+        visualizePCL(result,"inlier_cloud");
     }
 
-    // //===========================================================
-    // // Block 5: Least Squares Plane Fitting (OPEN3D-Based) TESTED
-    // //===========================================================
+    //===========================================================
+    // Block 5: Least Squares Plane Fitting (OPEN3D-Based)
+    //===========================================================
 
        {
 
@@ -89,9 +90,9 @@ int main(int argc, char **argv)
   
        }
 
-    // //===============================================================
-    // // Block 6: Least of Median Squares Plane Fitting (PCL-Based) TESTED
-    // //===============================================================
+    //==================================================================
+    // Block 6: Least of Median Squares Plane Fitting (PCL-Based) 
+    //==================================================================
 
       {
         float voxelSize = 0.15f;
@@ -105,33 +106,40 @@ int main(int argc, char **argv)
         // Visualize the result.
         visualizePCL(result);
       }
-    //===============================================================
+    // ===============================================================
     // Block 7: Average 3d Gradients (PCL-Based) not completed
-    //===============================================================
+    // ===============================================================
 
       {
-        double angle_threshold = 10.0;
-        double voxel_size = 0.1;
 
-        PCLResult result = Average3DGradientSegmentation(file_path, angle_threshold, voxel_size);
-        visualizePCL(result);
+        // Set default values for parameters
+        float voxelSize = 0.1f;
+        float neighborRadius = 0.5f;
+        float gradientThreshold = 0.15f;
+
+    
+
+        // Call the flatness detection function
+        PCLResult result = Average3DGradient(file_path, voxelSize, neighborRadius, gradientThreshold);
+        visualizePCL(result,"inlier_cloud");
+
 
       }
 
-    //===============================================================
-    // Block 8: Region growing segmentation (PCL-Based) TESTED
-    //===============================================================
+    // ===============================================================
+    // Block 8: Region growing segmentation (PCL-Based) 
+    // ===============================================================
 
       {
         double voxel_size = 0.45;
     
         PCLResult result = regionGrowingSegmentation(file_path, voxel_size);
-        visualizePCL(result);
+        visualizePCL(result,"inlier_cloud");
       
       }
     
     //===============================================================
-    // Block 9: Calculate Roughness (PCL-Based) TESTED
+    // Block 9: Calculate Roughness (PCL-Based) 
     //===============================================================
 
     { 
@@ -151,7 +159,7 @@ int main(int argc, char **argv)
     }
 
     //===============================================================
-    // Block 10: Calculate Roughness (OPEN3D-Based) TESTED
+    // Block 10: Calculate Roughness (OPEN3D-Based) 
     //===============================================================
 
      {
@@ -173,7 +181,7 @@ int main(int argc, char **argv)
      }
 
     //===============================================================
-    // Block 11: Calculate Relief (PCL-Based) TESTED
+    // Block 11: Calculate Relief (PCL-Based) 
     //===============================================================
 
     {
@@ -194,7 +202,7 @@ int main(int argc, char **argv)
 
 
     //===============================================================
-    // Block 12: Calculate Relief (OPEN3D-Based) TESTED
+    // Block 12: Calculate Relief (OPEN3D-Based) 
     //===============================================================
 
     {
@@ -214,7 +222,7 @@ int main(int argc, char **argv)
     }
 
     // ===============================================================
-    // Block 13: Calculate Data Confidence (PCL-Based) TESTED
+    // Block 13: Calculate Data Confidence (PCL-Based) 
     // ===============================================================
 
     {
@@ -235,7 +243,7 @@ int main(int argc, char **argv)
 
 
     // ===============================================================
-    // Block 14: Calculate Data Confidence (OPEN3D-Based) TESTED
+    // Block 14: Calculate Data Confidence (OPEN3D-Based) 
     // ===============================================================
 
     {
@@ -253,6 +261,8 @@ int main(int argc, char **argv)
       std::cout << "Stored plane model: " << segmentation_result.plane_model.transpose() << std::endl;
       std::cout << "data confidence of the safe landing zone open3d based : " << data_confidence<< std::endl;
     }
+
+    
 
     return 0;
 }

--- a/lib/hazard_metrices/main.cpp
+++ b/lib/hazard_metrices/main.cpp
@@ -11,15 +11,15 @@ int main(int argc, char **argv)
 
     {
 
-        float voxel_size =0.15f;
-        float slope_threshold = 20.0f;
+        float voxel_size =0.35f;
+        float slope_threshold = 5.0f;
         int k =10;
         
       // Get classification results including the downsampled point cloud.
-        PCLResult result = PrincipleComponentAnalysis<PointT>(file_path,    
-                                                              voxel_size ,
-                                                              slope_threshold,  // slope threshold
-                                                              k);    // k-nearest neighbors
+        PCLResult result = PrincipleComponentAnalysis(file_path,    
+                                                      voxel_size ,
+                                                      slope_threshold,  // slope threshold
+                                                      k);    // k-nearest neighbors
 
       // Use the stored downsampled point cloud in the visualization function.
         visualizePCL(result);

--- a/lib/hazard_metrices/main.cpp
+++ b/lib/hazard_metrices/main.cpp
@@ -1,0 +1,138 @@
+
+#include "hazard_metrices.h"
+
+int main(int argc, char **argv)
+{
+    // Input file (same for all blocks)
+    static const std::string file_path = "/home/airsim_user/Landing-Assist-Module-LAM/lib/hazard_metrices/test.pcd";
+
+    // pcl::PointCloud<pcl::PointXYZ>::Ptr original_cloud(new pcl::PointCloud<pcl::PointXYZ>);
+    // if (pcl::io::loadPCDFile<pcl::PointXYZ>(file_path, *original_cloud) == -1)
+    // {
+    //     PCL_ERROR("Couldn't read file %s\n", file_path.c_str());
+    //     return -1;
+    // }
+    // std::cout << "Loaded " << original_cloud->size() << " points from " << file_path << std::endl;
+
+    //=============================================================================================
+    //Block 1: PCA / Normal Estimation / Classification (PCL) TESTED BUT SPEED SHOULD BE INCREASED
+    //=============================================================================================
+    {
+
+        float voxel_size =0.45f;
+        float slope_threshold = 10.0f;
+        int k =10;
+        pcl::PointCloud<pcl::Normal>::Ptr normals(new pcl::PointCloud<pcl::Normal>);
+
+      // Get classification results including the downsampled point cloud.
+        PCLResult classification = computeNormalsAndClassifyPoints<PointT>(file_path,
+                                                                                           normals,
+                                                                                           voxel_size ,
+                                                                                           slope_threshold,  // slope threshold
+                                                                                           k);    // k-nearest neighbors
+
+      // Use the stored downsampled point cloud in the visualization function.
+        int point_size = 3;
+        visualizePCL(classification);
+ 
+    }
+
+    //======================================================
+    // Block 2: Open3D-Based RANSAC Segmentation TESTED
+    //======================================================
+    {
+      // Parameters for downsampling and RANSAC.
+      double voxel_size = 0.1;          // Example voxel size.
+      double distance_threshold = 1.9;   // Threshold for plane segmentation.
+      int ransac_n = 3;                  // Number of points to sample for plane fitting.
+      int num_iterations = 1000;         // Number of RANSAC iterations.
+
+      // Perform RANSAC plane segmentation.
+      OPEN3DResult result = RansacPlaneSegmentation(
+          file_path, voxel_size, distance_threshold, ransac_n, num_iterations);
+
+      // Visualize the segmentation result.
+      //VisualizeRansacSegmentationOpen3d(result.inlier_cloud, result.outlier_cloud);
+      VisualizeOPEN3D(result);
+    }
+
+    //======================================================
+    // Block 3: PCL-Based RANSAC Segmentation TESTED
+    //======================================================
+    {
+        float voxelSize = 0.15f;
+        float distanceThreshold = 1.9f;
+        int maxIterations = 1000;
+
+        PCLResult result = performRANSAC(file_path, voxelSize, distanceThreshold, maxIterations);
+        visualizePCL(result);
+        
+    }
+
+    //======================================================
+    // Block 4: PROSAC Segmentation (PCL-Based) TESTED
+    //======================================================
+    {
+        float voxel_size =0.15f;
+        float distanceThreshold = 1.9f;
+        int maxIterations = 200;
+
+        PCLResult result = performPROSAC(file_path, voxel_size, distanceThreshold,maxIterations);
+        visualizePCL(result);
+    }
+
+    //======================================================
+    // Block 5: Least Squares Plane Fitting (OPEN3D-Based) TESTED
+    //======================================================
+       {
+
+        OPEN3DResult result;
+
+        double voxel_size = 0.15;         // Voxel size for downsampling (adjust as needed)
+        double distance_threshold = 1.85; // Threshold for inlier classification (in same units as your point cloud)
+
+        result = LeastSquaresPlaneFitting(file_path, voxel_size, distance_threshold);
+        VisualizeOPEN3D(result);
+  
+       }
+    //===============================================================
+    // Block 6: Least of Median Squares Plane Fitting (PCL-Based) TESTED
+    //===============================================================
+
+      {
+        float voxelSize = 0.15f;
+        float distanceThreshold = 1.9f;
+        int maxIterations = 100;
+
+
+        // Perform plane fitting using LMedS.
+        PCLResult result = performLMEDS(file_path, voxelSize, distanceThreshold,maxIterations);
+        
+        // Visualize the result.
+        visualizePCL(result);
+      }
+    //===============================================================
+    // Block 7: Average 3d Gradients (PCL-Based) not completed
+    //===============================================================
+      // {
+      //   float slope_threshold = 20.0f;
+
+      //   // Compute normals and classify the points.
+      //   auto classified_clouds = computeNormalsUsingAverage3DGradient(original_cloud, slope_threshold);
+
+      //   // Visualize the inliers and outliers.
+      //   visualizeClassifiedCloud(classified_clouds.first, classified_clouds.second);
+      // }
+
+    //===============================================================
+    // Block 8: Region growing segmentation (PCL-Based) TESTED
+    //===============================================================
+      {
+        double voxel_size = 0.45;
+    
+        PCLResult result = regionGrowingSegmentation(file_path, voxel_size);
+        visualizePCL(result);
+      
+      }
+    return 0;
+}

--- a/lib/hazard_metrices/main.cpp
+++ b/lib/hazard_metrices/main.cpp
@@ -1,4 +1,3 @@
-
 #include "hazard_metrices.h"
 
 int main(int argc, char **argv)
@@ -9,10 +8,11 @@ int main(int argc, char **argv)
     //=============================================================================================
     //Block 1: PCA / Normal Estimation / Classification (PCL) TESTED BUT SPEED SHOULD BE INCREASED
     //=============================================================================================
+
     {
 
-        float voxel_size =0.45f;
-        float slope_threshold = 10.0f;
+        float voxel_size =0.15f;
+        float slope_threshold = 20.0f;
         int k =10;
         
       // Get classification results including the downsampled point cloud.
@@ -26,9 +26,10 @@ int main(int argc, char **argv)
 
     }
 
-    //======================================================
-    // Block 2: Open3D-Based RANSAC Segmentation TESTED
-    //======================================================
+    // //======================================================
+    // // Block 2: Open3D-Based RANSAC Segmentation TESTED
+    // //======================================================
+
     {
       // Parameters for downsampling and RANSAC.
       double voxel_size = 0.1;          // Example voxel size.
@@ -45,9 +46,10 @@ int main(int argc, char **argv)
       VisualizeOPEN3D(result);
     }
 
-    //======================================================
-    // Block 3: PCL-Based RANSAC Segmentation TESTED
-    //======================================================
+    // //======================================================
+    // // Block 3: PCL-Based RANSAC Segmentation TESTED
+    // //======================================================
+
     {
         float voxelSize = 0.15f;
         float distanceThreshold = 1.9f;
@@ -58,9 +60,10 @@ int main(int argc, char **argv)
         
     }
 
-    //======================================================
-    // Block 4: PROSAC Segmentation (PCL-Based) TESTED
-    //======================================================
+    // //======================================================
+    // // Block 4: PROSAC Segmentation (PCL-Based) TESTED
+    // //======================================================
+
     {
         float voxel_size =0.15f;
         float distanceThreshold = 1.9f;
@@ -70,9 +73,10 @@ int main(int argc, char **argv)
         visualizePCL(result);
     }
 
-    //======================================================
-    // Block 5: Least Squares Plane Fitting (OPEN3D-Based) TESTED
-    //======================================================
+    // //===========================================================
+    // // Block 5: Least Squares Plane Fitting (OPEN3D-Based) TESTED
+    // //===========================================================
+
        {
 
         OPEN3DResult result;
@@ -84,9 +88,10 @@ int main(int argc, char **argv)
         VisualizeOPEN3D(result);
   
        }
-    //===============================================================
-    // Block 6: Least of Median Squares Plane Fitting (PCL-Based) TESTED
-    //===============================================================
+
+    // //===============================================================
+    // // Block 6: Least of Median Squares Plane Fitting (PCL-Based) TESTED
+    // //===============================================================
 
       {
         float voxelSize = 0.15f;
@@ -103,19 +108,20 @@ int main(int argc, char **argv)
     //===============================================================
     // Block 7: Average 3d Gradients (PCL-Based) not completed
     //===============================================================
-      // {
-      //   float slope_threshold = 20.0f;
 
-      //   // Compute normals and classify the points.
-      //   auto classified_clouds = computeNormalsUsingAverage3DGradient(original_cloud, slope_threshold);
+      {
+        double angle_threshold = 10.0;
+        double voxel_size = 0.1;
 
-      //   // Visualize the inliers and outliers.
-      //   visualizeClassifiedCloud(classified_clouds.first, classified_clouds.second);
-      // }
+        PCLResult result = Average3DGradientSegmentation(file_path, angle_threshold, voxel_size);
+        visualizePCL(result);
+
+      }
 
     //===============================================================
     // Block 8: Region growing segmentation (PCL-Based) TESTED
     //===============================================================
+
       {
         double voxel_size = 0.45;
     
@@ -123,5 +129,130 @@ int main(int argc, char **argv)
         visualizePCL(result);
       
       }
+    
+    //===============================================================
+    // Block 9: Calculate Roughness (PCL-Based) TESTED
+    //===============================================================
+
+    { 
+      // Find the potential plane.
+      float voxel_size =0.15f;
+      float distanceThreshold = 1.9f;
+      int maxIterations = 200;
+
+      
+      PCLResult result = performPROSAC(file_path, voxel_size, distanceThreshold,maxIterations);
+      
+      double roughness = calculateRoughnessPCL(result);
+      if (roughness >= 0)
+        std::cout << "Roughness of the point cloud: " << roughness << std::endl;
+      else
+        std::cerr << "Failed to calculate roughness." << std::endl;
+    }
+
+    //===============================================================
+    // Block 10: Calculate Roughness (OPEN3D-Based) TESTED
+    //===============================================================
+
+     {
+      
+      double voxel_size = 0.1;
+      double distance_threshold = 1.9;
+      int ransac_n = 3;
+      int num_iterations = 1000;
+    
+      // Perform RANSAC segmentation.
+      OPEN3DResult segmentation_result = RansacPlaneSegmentation(file_path, voxel_size, distance_threshold, ransac_n, num_iterations);
+    
+      // Calculate roughness using the inlier cloud and the stored plane model.
+      double roughness = calculateRoughnessOpen3D(segmentation_result);
+    
+      std::cout << "Stored plane model: " << segmentation_result.plane_model.transpose() << std::endl;
+      std::cout << "Roughness of the safe landing zone: " << roughness << std::endl;
+
+     }
+
+    //===============================================================
+    // Block 11: Calculate Relief (PCL-Based) TESTED
+    //===============================================================
+
+    {
+            // Find the potential plane.
+      float voxel_size =0.15f;
+      float distanceThreshold = 1.9f;
+      int maxIterations = 200;
+
+      
+      PCLResult result = performPROSAC(file_path, voxel_size, distanceThreshold,maxIterations);
+      
+      double relief = calculateReliefPCL(result);
+      if (relief >= 0)
+        std::cout << "relief of the landing zone pcl based : " << relief << std::endl;
+      else
+        std::cerr << "Failed to calculate relief." << std::endl;
+    }
+
+
+    //===============================================================
+    // Block 12: Calculate Relief (OPEN3D-Based) TESTED
+    //===============================================================
+
+    {
+      double voxel_size = 0.1;
+      double distance_threshold = 1.9;
+      int ransac_n = 3;
+      int num_iterations = 1000;
+    
+      // Perform RANSAC segmentation.
+      OPEN3DResult segmentation_result = RansacPlaneSegmentation(file_path, voxel_size, distance_threshold, ransac_n, num_iterations);
+    
+      // Calculate relief using the inlier cloud and the stored plane model.
+      double relief = calculateReliefOpen3D(segmentation_result);
+    
+      std::cout << "Stored plane model: " << segmentation_result.plane_model.transpose() << std::endl;
+      std::cout << "relief of the safe landing zone open3d based : " << relief << std::endl;
+    }
+
+    // ===============================================================
+    // Block 13: Calculate Data Confidence (PCL-Based) TESTED
+    // ===============================================================
+
+    {
+            // Find the potential plane.
+      float voxel_size =0.15f;
+      float distanceThreshold = 1.9f;
+      int maxIterations = 200;
+
+      
+      PCLResult result = performPROSAC(file_path, voxel_size, distanceThreshold,maxIterations);
+      
+      double data_confidence= calculateDataConfidencePCL(result);
+      if (data_confidence>= 0)
+        std::cout << "data confidence of the landing zone pcl based : " << data_confidence<< std::endl;
+      else
+        std::cerr << "Failed to calculate relief." << std::endl;
+    }
+
+
+    // ===============================================================
+    // Block 14: Calculate Data Confidence (OPEN3D-Based) TESTED
+    // ===============================================================
+
+    {
+      double voxel_size = 0.01;
+      double distance_threshold = 1.9;
+      int ransac_n = 3;
+      int num_iterations = 1000;
+    
+      // Perform RANSAC segmentation.
+      OPEN3DResult segmentation_result = RansacPlaneSegmentation(file_path, voxel_size, distance_threshold, ransac_n, num_iterations);
+    
+      // Calculate data_confidenceusing the inlier cloud and the stored plane model.
+      double data_confidence= calculateDataConfidenceOpen3D(segmentation_result);
+    
+      std::cout << "Stored plane model: " << segmentation_result.plane_model.transpose() << std::endl;
+      std::cout << "data confidence of the safe landing zone open3d based : " << data_confidence<< std::endl;
+    }
+
     return 0;
 }

--- a/lib/hazard_metrices/test_hazard_metrices.cpp
+++ b/lib/hazard_metrices/test_hazard_metrices.cpp
@@ -152,9 +152,10 @@ TEST(HazardMetricesTest, TestAverage3DGradient) {
     float voxelSize = 0.1f;
     float neighborRadius = 0.5f;
     float gradientThreshold = 0.15f;
+    float angleThreshold = 10.0f;
 
     // Call the Average3DGradient flatness detection function.
-    PCLResult result = Average3DGradient(file_path, voxelSize, neighborRadius, gradientThreshold);
+    PCLResult result = Average3DGradient(file_path, voxelSize, neighborRadius, gradientThreshold, angleThreshold);
 
     if (!g_skipVisualization) {
         // Visualize the result using visualizePCL, with "inlier_cloud" tag.

--- a/lib/hazard_metrices/test_hazard_metrices.cpp
+++ b/lib/hazard_metrices/test_hazard_metrices.cpp
@@ -12,7 +12,26 @@ static const std::string file_path = "/home/airsim_user/Landing-Assist-Module-LA
 //--------------------------------------------------------------------------
 // Test 1: PCA / Normal Estimation / Classification (PCL)
 //--------------------------------------------------------------------------
+TEST(HazardMetricesTest, TestPCA_NormalEstimation) {
+    float voxel_size = 0.15f;
+    float slope_threshold = 20.0f;
+    int k = 10;
+    // Call the PCA-based classification function.
+    PCLResult result =  PrincipleComponentAnalysis<PointT>(file_path,
+                                                               voxel_size,
+                                                               slope_threshold,
+                                                               k);
+    if (!g_skipVisualization) {
+        // Visualize the result; press 'q' to close the viewer.
+        visualizePCL(result);
+    } else {
 
+        std::cout << "[TestPCA_NormalEstimation] Inliers: " << result.inlier_cloud->size()  << ", Outliers: " << result.outlier_cloud->size() << std::endl;
+    }
+    // Check that some points have been classified.
+    EXPECT_GT(result.inlier_cloud->size() + result.outlier_cloud->size(), 0);
+
+}
 //--------------------------------------------------------------------------
 // Test 2: Open3D-Based RANSAC Segmentation
 //-------------------------------------------------------------------------- 
@@ -141,6 +160,125 @@ TEST(HazardMetricesTest, TestRegionGrowing) {
     // Check that some inliers are detected.
     EXPECT_GT(result.inlier_cloud->size(), 0);
 }
+
+
+//--------------------------------------------------------------------------
+// Test 8: Calculate Roughness (PCL-Based)
+//--------------------------------------------------------------------------
+TEST(HazardMetricesTest, TestRoughnessPCL) {
+    float voxel_size = 0.15f;
+    float distanceThreshold = 1.9f;
+    int maxIterations = 200;
+
+    // Perform PROSAC segmentation (PCL-based)
+    PCLResult result = performPROSAC(file_path, voxel_size, distanceThreshold, maxIterations);
+
+    // Calculate roughness using the PCL-based method.
+    double roughness = calculateRoughnessPCL(result);
+    std::cout << "[TestRoughnessPCL] Roughness of the point cloud: " << roughness << std::endl;
+    
+    // Verify that a valid roughness value was calculated.
+    EXPECT_GE(roughness, 0);
+}
+
+//--------------------------------------------------------------------------
+// Test 9: Calculate Roughness (Open3D-Based)
+//--------------------------------------------------------------------------
+TEST(HazardMetricesTest, TestRoughnessOpen3D) {
+    double voxel_size = 0.1;
+    double distance_threshold = 1.9;
+    int ransac_n = 3;
+    int num_iterations = 1000;
+
+    // Perform RANSAC segmentation (Open3D-based)
+    OPEN3DResult segmentation_result = RansacPlaneSegmentation(file_path, voxel_size, distance_threshold, ransac_n, num_iterations);
+
+    // Calculate roughness using the Open3D-based method.
+    double roughness = calculateRoughnessOpen3D(segmentation_result);
+    std::cout << "[TestRoughnessOpen3D] Roughness of the safe landing zone: " << roughness << std::endl;
+    
+    // Verify that a valid roughness value was calculated.
+    EXPECT_GE(roughness, 0);
+}
+
+//--------------------------------------------------------------------------
+// Test 10: Calculate Relief (PCL-Based)
+//--------------------------------------------------------------------------
+TEST(HazardMetricesTest, TestReliefPCL) {
+    float voxel_size = 0.15f;
+    float distanceThreshold = 1.9f;
+    int maxIterations = 200;
+
+    // Perform PROSAC segmentation (PCL-based)
+    PCLResult result = performPROSAC(file_path, voxel_size, distanceThreshold, maxIterations);
+
+    // Calculate relief using the PCL-based method.
+    double relief = calculateReliefPCL(result);
+    std::cout << "[TestReliefPCL] Relief of the landing zone (PCL-based): " << relief << std::endl;
+    
+    // Verify that a valid relief value was calculated.
+    EXPECT_GE(relief, 0);
+}
+
+//--------------------------------------------------------------------------
+// Test 11: Calculate Relief (Open3D-Based)
+//--------------------------------------------------------------------------
+TEST(HazardMetricesTest, TestReliefOpen3D) {
+    double voxel_size = 0.1;
+    double distance_threshold = 1.9;
+    int ransac_n = 3;
+    int num_iterations = 1000;
+
+    // Perform RANSAC segmentation (Open3D-based)
+    OPEN3DResult segmentation_result = RansacPlaneSegmentation(file_path, voxel_size, distance_threshold, ransac_n, num_iterations);
+
+    // Calculate relief using the Open3D-based method.
+    double relief = calculateReliefOpen3D(segmentation_result);
+    std::cout << "[TestReliefOpen3D] Relief of the safe landing zone (Open3D-based): " << relief << std::endl;
+    
+    // Verify that a valid relief value was calculated.
+    EXPECT_GE(relief, 0);
+}
+
+//--------------------------------------------------------------------------
+// Test 12: Calculate Data Confidence (PCL-Based)
+//--------------------------------------------------------------------------
+TEST(HazardMetricesTest, TestDataConfidencePCL) {
+    float voxel_size = 0.15f;
+    float distanceThreshold = 1.9f;
+    int maxIterations = 200;
+
+    // Perform PROSAC segmentation (PCL-based)
+    PCLResult result = performPROSAC(file_path, voxel_size, distanceThreshold, maxIterations);
+
+    // Calculate data confidence using the PCL-based method.
+    double data_confidence = calculateDataConfidencePCL(result);
+    std::cout << "[TestDataConfidencePCL] Data confidence (PCL-based): " << data_confidence << std::endl;
+    
+    // Verify that a valid data confidence value was calculated.
+    EXPECT_GE(data_confidence, 0);
+}
+
+//--------------------------------------------------------------------------
+// Test 13: Calculate Data Confidence (Open3D-Based)
+//--------------------------------------------------------------------------
+TEST(HazardMetricesTest, TestDataConfidenceOpen3D) {
+    double voxel_size = 0.01;
+    double distance_threshold = 1.9;
+    int ransac_n = 3;
+    int num_iterations = 1000;
+
+    // Perform RANSAC segmentation (Open3D-based)
+    OPEN3DResult segmentation_result = RansacPlaneSegmentation(file_path, voxel_size, distance_threshold, ransac_n, num_iterations);
+
+    // Calculate data confidence using the Open3D-based method.
+    double data_confidence = calculateDataConfidenceOpen3D(segmentation_result);
+    std::cout << "[TestDataConfidenceOpen3D] Data confidence (Open3D-based): " << data_confidence << std::endl;
+    
+    // Verify that a valid data confidence value was calculated.
+    EXPECT_GE(data_confidence, 0);
+}
+
 
 //--------------------------------------------------------------------------
 // main() for Google Test

--- a/lib/hazard_metrices/test_hazard_metrices.cpp
+++ b/lib/hazard_metrices/test_hazard_metrices.cpp
@@ -1,0 +1,181 @@
+#include "hazard_metrices.h"
+#include <gtest/gtest.h>
+#include <string>
+#include <iostream>
+
+// Global flag to control visualization in tests.
+bool g_skipVisualization = false;
+
+// Input file path (adjust if needed)
+static const std::string file_path = "/home/airsim_user/Landing-Assist-Module-LAM/lib/hazard_metrices/test.pcd";
+
+//--------------------------------------------------------------------------
+// Test 1: PCA / Normal Estimation / Classification (PCL)
+//--------------------------------------------------------------------------
+TEST(HazardMetricesTest, TestPCA_NormalEstimation) {
+    float voxel_size = 0.45f;
+    float slope_threshold = 10.0f;
+    int k = 10;
+    pcl::PointCloud<pcl::Normal>::Ptr normals(new pcl::PointCloud<pcl::Normal>);
+
+    // Call the PCA-based classification function.
+    PCLResult result = computeNormalsAndClassifyPoints<PointT>(file_path,
+                                                               normals,
+                                                               voxel_size,
+                                                               slope_threshold,
+                                                               k);
+    if (!g_skipVisualization) {
+        // Visualize the result; press 'q' to close the viewer.
+        visualizePCL(result);
+    } else {
+        std::cout << "[TestPCA_NormalEstimation] Inliers: " << result.inlier_cloud->size() 
+                  << ", Outliers: " << result.outlier_cloud->size() << std::endl;
+    }
+    // Check that some points have been classified.
+    EXPECT_GT(result.inlier_cloud->size() + result.outlier_cloud->size(), 0);
+}
+
+//--------------------------------------------------------------------------
+// Test 2: Open3D-Based RANSAC Segmentation
+//-------------------------------------------------------------------------- 
+TEST(HazardMetricesTest, TestOpen3D_RANSAC) {
+    double voxel_size = 0.1;
+    double distance_threshold = 1.9;
+    int ransac_n = 3;
+    int num_iterations = 1000;
+
+    // Call the Open3D RANSAC segmentation function.
+    OPEN3DResult result = RansacPlaneSegmentation(file_path, voxel_size, distance_threshold, ransac_n, num_iterations);
+
+    if (!g_skipVisualization) {
+        // Visualize the segmentation result; press 'q' to close the window.
+        VisualizeOPEN3D(result);
+    } else {
+        std::cout << "[TestOpen3D_RANSAC] Inliers: " << result.inlier_cloud->points_.size()
+                  << ", Outliers: " << result.outlier_cloud->points_.size() << std::endl;
+    }
+    // Verify that inliers and outliers were produced.
+    EXPECT_GT(result.inlier_cloud->points_.size(), 0);
+    EXPECT_GT(result.outlier_cloud->points_.size(), 0);
+}
+
+//--------------------------------------------------------------------------
+// Test 3: PCL-Based RANSAC Segmentation
+//-------------------------------------------------------------------------- 
+TEST(HazardMetricesTest, TestPCL_RANSAC) {
+    float voxelSize = 0.15f;
+    float distanceThreshold = 1.9f;
+    int maxIterations = 1000;
+
+    // Call the PCL RANSAC segmentation function.
+    PCLResult result = performRANSAC(file_path, voxelSize, distanceThreshold, maxIterations);
+
+    if (!g_skipVisualization) {
+        visualizePCL(result);
+    } else {
+        std::cout << "[TestPCL_RANSAC] Inliers: " << result.inlier_cloud->size()
+                  << ", Outliers: " << result.outlier_cloud->size() << std::endl;
+    }
+    // Verify that both inliers and outliers were found.
+    EXPECT_GT(result.inlier_cloud->size(), 0);
+    EXPECT_GT(result.outlier_cloud->size(), 0);
+}
+
+//--------------------------------------------------------------------------
+// Test 4: PROSAC Segmentation (PCL-Based)
+//--------------------------------------------------------------------------
+TEST(HazardMetricesTest, TestPROSAC) {
+    float voxel_size = 0.15f;
+    float distanceThreshold = 1.9f;
+    int maxIterations = 200;
+
+    // Call the PROSAC segmentation function.
+    PCLResult result = performPROSAC(file_path, voxel_size, distanceThreshold, maxIterations);
+
+    if (!g_skipVisualization) {
+        visualizePCL(result);
+    } else {
+        std::cout << "[TestPROSAC] Inliers: " << result.inlier_cloud->size()
+                  << ", Outliers: " << result.outlier_cloud->size() << std::endl;
+    }
+    // Check that segmentation produced inliers and outliers.
+    EXPECT_GT(result.inlier_cloud->size(), 0);
+    EXPECT_GT(result.outlier_cloud->size(), 0);
+}
+
+//--------------------------------------------------------------------------
+// Test 5: Least Squares Plane Fitting (OPEN3D-Based)
+//--------------------------------------------------------------------------
+TEST(HazardMetricesTest, TestLeastSquaresPlaneFitting) {
+    double voxel_size = 0.15;
+    double distance_threshold = 1.85;
+
+    // Call the Least Squares plane fitting function.
+    OPEN3DResult result = LeastSquaresPlaneFitting(file_path, voxel_size, distance_threshold);
+
+    if (!g_skipVisualization) {
+        VisualizeOPEN3D(result);
+    } else {
+        std::cout << "[TestLeastSquaresPlaneFitting] Inliers: " << result.inlier_cloud->points_.size()
+                  << ", Outliers: " << result.outlier_cloud->points_.size() << std::endl;
+    }
+    // Verify that the function produced inliers and outliers.
+    EXPECT_GT(result.inlier_cloud->points_.size(), 0);
+    EXPECT_GT(result.outlier_cloud->points_.size(), 0);
+}
+
+//--------------------------------------------------------------------------
+// Test 6: LMEDS Plane Fitting (PCL-Based)
+//--------------------------------------------------------------------------
+TEST(HazardMetricesTest, TestLMEDS) {
+    float voxelSize = 0.15f;
+    float distanceThreshold = 1.9f;
+    int maxIterations = 100;
+
+    // Call the LMEDS segmentation function.
+    PCLResult result = performLMEDS(file_path, voxelSize, distanceThreshold, maxIterations);
+
+    if (!g_skipVisualization) {
+        visualizePCL(result);
+    } else {
+        std::cout << "[TestLMEDS] Inliers: " << result.inlier_cloud->size()
+                  << ", Outliers: " << result.outlier_cloud->size() << std::endl;
+    }
+    // Ensure that inliers and outliers are found.
+    EXPECT_GT(result.inlier_cloud->size(), 0);
+    EXPECT_GT(result.outlier_cloud->size(), 0);
+}
+
+//--------------------------------------------------------------------------
+// Test 7: Region Growing Segmentation (PCL-Based)
+//--------------------------------------------------------------------------
+TEST(HazardMetricesTest, TestRegionGrowing) {
+    double voxel_size = 0.45;
+
+    // Call the region growing segmentation function.
+    PCLResult result = regionGrowingSegmentation(file_path, voxel_size);
+
+    if (!g_skipVisualization) {
+        visualizePCL(result);
+    } else {
+        std::cout << "[TestRegionGrowing] Inliers: " << result.inlier_cloud->size() << std::endl;
+    }
+    // Check that some inliers are detected.
+    EXPECT_GT(result.inlier_cloud->size(), 0);
+}
+
+//--------------------------------------------------------------------------
+// main() for Google Test
+//--------------------------------------------------------------------------
+int main(int argc, char **argv) {
+    // Process additional command-line arguments.
+    for (int i = 1; i < argc; ++i) {
+        std::string arg(argv[i]);
+        if (arg == "--no-vis") {
+            g_skipVisualization = true;
+        }
+    }
+    
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}

--- a/lib/hazard_metrices/test_hazard_metrices.cpp
+++ b/lib/hazard_metrices/test_hazard_metrices.cpp
@@ -144,7 +144,32 @@ TEST(HazardMetricesTest, TestLMEDS) {
 }
 
 //--------------------------------------------------------------------------
-// Test 7: Region Growing Segmentation (PCL-Based)
+// Test 7: Average 3d Gradient (PCL-Based)
+//--------------------------------------------------------------------------
+
+TEST(HazardMetricesTest, TestAverage3DGradient) {
+    // Set default values for parameters.
+    float voxelSize = 0.1f;
+    float neighborRadius = 0.5f;
+    float gradientThreshold = 0.15f;
+
+    // Call the Average3DGradient flatness detection function.
+    PCLResult result = Average3DGradient(file_path, voxelSize, neighborRadius, gradientThreshold);
+
+    if (!g_skipVisualization) {
+        // Visualize the result using visualizePCL, with "inlier_cloud" tag.
+        visualizePCL(result);
+    } else {
+        std::cout << "[TestAverage3DGradient] Inliers: " << result.inlier_cloud->size() 
+                  << ", Outliers: " << result.outlier_cloud->size() << std::endl;
+    }
+    // Ensure that some points have been classified.
+    EXPECT_GT(result.inlier_cloud->size() + result.outlier_cloud->size(), 0);
+}
+
+
+//--------------------------------------------------------------------------
+// Test 8: Region Growing Segmentation (PCL-Based)
 //--------------------------------------------------------------------------
 TEST(HazardMetricesTest, TestRegionGrowing) {
     double voxel_size = 0.45;
@@ -163,7 +188,7 @@ TEST(HazardMetricesTest, TestRegionGrowing) {
 
 
 //--------------------------------------------------------------------------
-// Test 8: Calculate Roughness (PCL-Based)
+// Test 9: Calculate Roughness (PCL-Based)
 //--------------------------------------------------------------------------
 TEST(HazardMetricesTest, TestRoughnessPCL) {
     float voxel_size = 0.15f;
@@ -182,7 +207,7 @@ TEST(HazardMetricesTest, TestRoughnessPCL) {
 }
 
 //--------------------------------------------------------------------------
-// Test 9: Calculate Roughness (Open3D-Based)
+// Test 10: Calculate Roughness (Open3D-Based)
 //--------------------------------------------------------------------------
 TEST(HazardMetricesTest, TestRoughnessOpen3D) {
     double voxel_size = 0.1;
@@ -202,7 +227,7 @@ TEST(HazardMetricesTest, TestRoughnessOpen3D) {
 }
 
 //--------------------------------------------------------------------------
-// Test 10: Calculate Relief (PCL-Based)
+// Test 11: Calculate Relief (PCL-Based)
 //--------------------------------------------------------------------------
 TEST(HazardMetricesTest, TestReliefPCL) {
     float voxel_size = 0.15f;
@@ -221,7 +246,7 @@ TEST(HazardMetricesTest, TestReliefPCL) {
 }
 
 //--------------------------------------------------------------------------
-// Test 11: Calculate Relief (Open3D-Based)
+// Test 12: Calculate Relief (Open3D-Based)
 //--------------------------------------------------------------------------
 TEST(HazardMetricesTest, TestReliefOpen3D) {
     double voxel_size = 0.1;
@@ -241,7 +266,7 @@ TEST(HazardMetricesTest, TestReliefOpen3D) {
 }
 
 //--------------------------------------------------------------------------
-// Test 12: Calculate Data Confidence (PCL-Based)
+// Test 13: Calculate Data Confidence (PCL-Based)
 //--------------------------------------------------------------------------
 TEST(HazardMetricesTest, TestDataConfidencePCL) {
     float voxel_size = 0.15f;
@@ -260,7 +285,7 @@ TEST(HazardMetricesTest, TestDataConfidencePCL) {
 }
 
 //--------------------------------------------------------------------------
-// Test 13: Calculate Data Confidence (Open3D-Based)
+// Test 14: Calculate Data Confidence (Open3D-Based)
 //--------------------------------------------------------------------------
 TEST(HazardMetricesTest, TestDataConfidenceOpen3D) {
     double voxel_size = 0.01;

--- a/lib/hazard_metrices/test_hazard_metrices.cpp
+++ b/lib/hazard_metrices/test_hazard_metrices.cpp
@@ -12,28 +12,6 @@ static const std::string file_path = "/home/airsim_user/Landing-Assist-Module-LA
 //--------------------------------------------------------------------------
 // Test 1: PCA / Normal Estimation / Classification (PCL)
 //--------------------------------------------------------------------------
-TEST(HazardMetricesTest, TestPCA_NormalEstimation) {
-    float voxel_size = 0.45f;
-    float slope_threshold = 10.0f;
-    int k = 10;
-    pcl::PointCloud<pcl::Normal>::Ptr normals(new pcl::PointCloud<pcl::Normal>);
-
-    // Call the PCA-based classification function.
-    PCLResult result = computeNormalsAndClassifyPoints<PointT>(file_path,
-                                                               normals,
-                                                               voxel_size,
-                                                               slope_threshold,
-                                                               k);
-    if (!g_skipVisualization) {
-        // Visualize the result; press 'q' to close the viewer.
-        visualizePCL(result);
-    } else {
-        std::cout << "[TestPCA_NormalEstimation] Inliers: " << result.inlier_cloud->size() 
-                  << ", Outliers: " << result.outlier_cloud->size() << std::endl;
-    }
-    // Check that some points have been classified.
-    EXPECT_GT(result.inlier_cloud->size() + result.outlier_cloud->size(), 0);
-}
 
 //--------------------------------------------------------------------------
 // Test 2: Open3D-Based RANSAC Segmentation

--- a/lib/hazard_metrices/test_hazard_metrices.cpp
+++ b/lib/hazard_metrices/test_hazard_metrices.cpp
@@ -13,14 +13,14 @@ static const std::string file_path = "/home/airsim_user/Landing-Assist-Module-LA
 // Test 1: PCA / Normal Estimation / Classification (PCL)
 //--------------------------------------------------------------------------
 TEST(HazardMetricesTest, TestPCA_NormalEstimation) {
-    float voxel_size = 0.15f;
-    float slope_threshold = 20.0f;
+    float voxel_size = 0.35f;
+    float slope_threshold = 5.0f;
     int k = 10;
     // Call the PCA-based classification function.
-    PCLResult result =  PrincipleComponentAnalysis<PointT>(file_path,
-                                                               voxel_size,
-                                                               slope_threshold,
-                                                               k);
+    PCLResult result =  PrincipleComponentAnalysis(file_path,
+                                                    voxel_size,
+                                                    slope_threshold,
+                                                    k);
     if (!g_skipVisualization) {
         // Visualize the result; press 'q' to close the viewer.
         visualizePCL(result);

--- a/lib/preprocessing/CMakeLists.txt
+++ b/lib/preprocessing/CMakeLists.txt
@@ -42,14 +42,26 @@ include_directories(
     /usr/local/include/pcl-1.14
 
 )
-  
+
 # ----------------------------------------------------------------------------
-# 4. Create the executable
+# 4. Find VTK components (required by Open3D's third-party VTK modules)
+# ----------------------------------------------------------------------------
+
+# If you want to specify them, do:
+# find_package(VTK REQUIRED COMPONENTS FiltersGeneral FiltersModeling FiltersCore CommonDataModel CommonExecutionModel)
+
+
+set(CMAKE_EXE_LINKER_FLAGS
+    "${CMAKE_EXE_LINKER_FLAGS} -Wl,--copy-dt-needed-entries"
+)
+
+# ----------------------------------------------------------------------------
+# 5. Create the executable
 # ----------------------------------------------------------------------------
 add_executable(main main.cpp)
 
 # ----------------------------------------------------------------------------
-# 5. Link libraries
+# 6. Link libraries
 #    - PCL libraries (from find_package)
 #    - OpenMP (if found)
 #    - Other manually specified libraries

--- a/lib/preprocessing/CMakeLists.txt
+++ b/lib/preprocessing/CMakeLists.txt
@@ -1,0 +1,81 @@
+cmake_minimum_required(VERSION 3.10)
+project(Preprocessing)
+
+# Use C++17
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+# ----------------------------------------------------------------------------
+# 1. Find OPEN3d,PCL and include the necessary modules
+#    (Add 'io' if you need loadPCDFile())
+# ----------------------------------------------------------------------------
+
+find_package(Open3D REQUIRED)
+
+find_package(PCL 1.4 REQUIRED COMPONENTS common filters io visualization)
+include_directories(${PCL_INCLUDE_DIRS})
+add_definitions(${PCL_DEFINITIONS})
+
+find_package(octomap REQUIRED)  # This will set OCTOMAP_INCLUDE_DIRS & OCTOMAP_LIBRARIES
+include_directories(${OCTOMAP_INCLUDE_DIRS})
+# add_definitions(${OCTOMAP_DEFINITIONS})
+
+# ----------------------------------------------------------------------------
+# 2. Optionally, find OpenMP if needed for parallelization
+# ----------------------------------------------------------------------------
+find_package(OpenMP REQUIRED)
+if(OPENMP_FOUND)
+    # Let CMake automatically add the correct compile/link flags
+    # for OpenMP instead of manually using -fopenmp or -lgomp
+    # (This is the recommended modern approach)
+    message(STATUS "OpenMP found. Linking to OpenMP libraries.")
+endif()
+
+# ----------------------------------------------------------------------------
+# 3. Manually include other libraries' include paths
+#    (Only do this if you do NOT rely on pkg-config or CMake find_package
+#     for these libraries)
+# ----------------------------------------------------------------------------
+include_directories(
+   
+    /usr/local/include/eigen3
+    /usr/local/include/pcl-1.14
+
+)
+  
+# ----------------------------------------------------------------------------
+# 4. Create the executable
+# ----------------------------------------------------------------------------
+add_executable(main main.cpp)
+
+# ----------------------------------------------------------------------------
+# 5. Link libraries
+#    - PCL libraries (from find_package)
+#    - OpenMP (if found)
+#    - Other manually specified libraries
+# ----------------------------------------------------------------------------
+
+ 
+target_link_libraries(main
+    PRIVATE
+    Open3D::Open3D                  # -lOpen3D
+    ${PCL_LIBRARIES} 
+    ${OCTOMAP_LIBRARIES}  
+    octomap 
+    octomath
+    GL                     # -lGL
+    GLU                    # -lGLU
+    glfw                   # -lglfw
+    GLEW                   # -lGLEW
+    assimp                 # -lassimp
+    jsoncpp               # -ljsoncpp
+    jpeg                   # -ljpeg
+    png                    # -lpng
+    z                      # -lz
+    pthread                # -lpthread
+)
+
+# Link OpenMP last to ensure correct symbol resolution
+if(OPENMP_FOUND)
+    target_link_libraries(main PRIVATE OpenMP::OpenMP_CXX)
+endif()

--- a/lib/preprocessing/CMakeLists.txt
+++ b/lib/preprocessing/CMakeLists.txt
@@ -75,6 +75,25 @@ target_link_libraries(main
     pthread                # -lpthread
 )
 
+add_executable(test_pointcloud_preprocessing test_pointcloud_preprocessing.cpp)
+target_link_libraries(test_pointcloud_preprocessing 
+    ${PCL_LIBRARIES} 
+    Open3D::Open3D 
+    octomap 
+    gtest 
+    gtest_main
+    GL                     # -lGL
+    GLU                    # -lGLU
+    glfw                   # -lglfw
+    GLEW                   # -lGLEW
+    assimp                 # -lassimp
+    jsoncpp               # -ljsoncpp
+    jpeg                   # -ljpeg
+    png                    # -lpng
+    z                      # -lz
+    pthread                # -lpthread
+)
+
 # Link OpenMP last to ensure correct symbol resolution
 if(OPENMP_FOUND)
     target_link_libraries(main PRIVATE OpenMP::OpenMP_CXX)

--- a/lib/preprocessing/main.cpp
+++ b/lib/preprocessing/main.cpp
@@ -5,9 +5,9 @@ int main(int argc, char **argv)
     //// Define the input PCD file path.
     std::string filename = "/home/airsim_user/Landing-Assist-Module-LAM/lib/preprocessing/3_7_2024_dense.pcd";
 
-    /////////////////////////////////////////////////////////////////////////////////////////////////////
-    // DATA STRUCTURING
-    /////////////////////////////////////////////////////////////////////////////////////////////////////
+    //=================================================================================================
+    //============================= DATA STRUCTURING ==================================================
+    //=================================================================================================
 
     // Create and visualize a 2D Grid Map.
     float gridmap_resolution = 0.1f;
@@ -47,9 +47,9 @@ int main(int argc, char **argv)
     double octomap_resolution = 0.05;
     convertPointCloudToOctomap(filename, octomap_filename, octomap_resolution);
 
-    /////////////////////////////////////////////////////////////////////////////////////////////////////
-    // FILTERING
-    /////////////////////////////////////////////////////////////////////////////////////////////////////
+    //=================================================================================================
+    //======================================= FILTERING ===============================================
+    //=================================================================================================
 
     //// Apply voxel grid filter using Open3D and visualize.
     double voxel_downsample_size = 0.15;
@@ -70,9 +70,9 @@ int main(int argc, char **argv)
     }
     visualize_sor_filtered_point_cloud(sor_result.original_cloud, sor_result.filtered_cloud);
 
-    // ////////////////////////////////////////////////////////////////////////////////////////////////////////
-    // /////////////////////////FILTERING USING PCL///////////////////////////////////////////////////////////
-    // //////////////////////////////////////////////////////////////////////////////////////////////////////
+    // ========================================================================================================
+    // ============================= FILTERING USING PCL ======================================================
+    // ========================================================================================================
 
     // //// For further filtering with PCL, load the point cloud as PointXYZI.
     pcl::PointCloud<pcl::PointXYZI>::Ptr cloud_original(new pcl::PointCloud<pcl::PointXYZI>());
@@ -86,9 +86,11 @@ int main(int argc, char **argv)
     float leaf_size = 0.1f;
     auto cloud_downsampled = downsamplePointCloud<pcl::PointXYZI>(cloud_original, leaf_size);
 
-    // // /////////////////////////////////////////////////////////////////////////////////////////////////////
-    // // // WHile using this code comment line 78 to 87 ,this function use voxeldownsampled pointcloud
-    // // //// --- Radius Outlier Removal Filter (PCL) ---
+    //=========================================================================================================================
+    // ============= WHile using this code comment line 78 to 87 ,this function use voxeldownsampled pointcloud================
+    // ================= Radius Outlier Removal Filter (PCL) ==================================================================
+    //=========================================================================================================================
+
     double radius_search = 0.1; //0.1 to 0.3,0.3 to 0.7,0.7 to 0.15
     int min_neighbors = 4;      // 5 to 15,10 to 30,20 to 50
     float translation_offset_radius_filter = 0.0f; //change this value to visualize the filtered cloud in a different position along x axis if it 0 filtered and original pointcloud will be in the same position
@@ -106,14 +108,17 @@ int main(int argc, char **argv)
         std::cerr << "[ERROR] Radius Outlier Removal resulted in an empty cloud. Skipping visualization." << std::endl;
     }
 
-    // // ////// --- Bilateral Filter (PCL) ---
-    // // //// WHile using this code comment line 78 to 87 ,this function use voxeldownsampled pointcloud
+    //============================= Bilateral Filter (PCL) =================================================================================================================================================================
+    //==================== WHile using this code comment line 78 to 87 ,this function use voxeldownsampled pointcloud=======================================================================================================
+    
     double sigma_s = 15.0; // Small point clouds or detailed structures: sigma_s = 1.0 - 5.0 ,Noisy or dense point clouds: sigma_s = 5.0 - 10.0,Large or very noisy point clouds: sigma_s = 10.0 - 15.0
     double sigma_r = 0.3;  //Preserve edges and details: sigma_r = 0.05 - 0.1, Moderate smoothing: sigma_r = 0.1 - 0.2, Heavy denoising (risk of over-smoothing): sigma_r = 0.2 - 0.3
     float translation_offset_bilateral_filter = 0.0f; //change this value to visualize the filtered cloud in a different position along x axis if it 0 filtered and original pointcloud will be in the same position
+    
     std::cout << "[SETTINGS] filename: " << filename
               << ", sigma_s: " << sigma_s
               << ", sigma_r: " << sigma_r << std::endl;
+
     auto cloud_bilateral_filtered = applyBilateralFilter<pcl::PointXYZI>(cloud_downsampled, sigma_s, sigma_r);
     if (!cloud_bilateral_filtered->empty()) {
         visualizeClouds<pcl::PointXYZI>(cloud_downsampled, cloud_bilateral_filtered,

--- a/lib/preprocessing/main.cpp
+++ b/lib/preprocessing/main.cpp
@@ -91,7 +91,7 @@ int main(int argc, char **argv)
     // // //// --- Radius Outlier Removal Filter (PCL) ---
     double radius_search = 0.1; //0.1 to 0.3,0.3 to 0.7,0.7 to 0.15
     int min_neighbors = 4;      // 5 to 15,10 to 30,20 to 50
-    float translation_offset = 0.0f; //change this value to visualize the filtered cloud in a different position along x axis if it 0 filtered and original pointcloud will be in the same position
+    float translation_offset_radius_filter = 0.0f; //change this value to visualize the filtered cloud in a different position along x axis if it 0 filtered and original pointcloud will be in the same position
     std::cout << "[SETTINGS] filename: " << filename
               << ", radius_search: " << radius_search
               << ", min_neighbors: " << min_neighbors << std::endl;
@@ -101,7 +101,7 @@ int main(int argc, char **argv)
                                          "Radius Outlier Removal",
                                          "original cloud",
                                          "radius_filtered cloud",
-                                         2, translation_offset);
+                                         2, translation_offset_radius_filter);
     } else {
         std::cerr << "[ERROR] Radius Outlier Removal resulted in an empty cloud. Skipping visualization." << std::endl;
     }
@@ -110,7 +110,7 @@ int main(int argc, char **argv)
     // // //// WHile using this code comment line 78 to 87 ,this function use voxeldownsampled pointcloud
     double sigma_s = 15.0; // Small point clouds or detailed structures: sigma_s = 1.0 - 5.0 ,Noisy or dense point clouds: sigma_s = 5.0 - 10.0,Large or very noisy point clouds: sigma_s = 10.0 - 15.0
     double sigma_r = 0.3;  //Preserve edges and details: sigma_r = 0.05 - 0.1, Moderate smoothing: sigma_r = 0.1 - 0.2, Heavy denoising (risk of over-smoothing): sigma_r = 0.2 - 0.3
-    float translation_offset = 0.0f; //change this value to visualize the filtered cloud in a different position along x axis if it 0 filtered and original pointcloud will be in the same position
+    float translation_offset_bilateral_filter = 0.0f; //change this value to visualize the filtered cloud in a different position along x axis if it 0 filtered and original pointcloud will be in the same position
     std::cout << "[SETTINGS] filename: " << filename
               << ", sigma_s: " << sigma_s
               << ", sigma_r: " << sigma_r << std::endl;
@@ -120,7 +120,7 @@ int main(int argc, char **argv)
                                          "Bilateral Filter",
                                          "original cloud",
                                          "bilateral_filtered cloud",
-                                         2, translation_offset);
+                                         2, translation_offset_bilateral_filter);
     } else {
         std::cerr << "[ERROR] Bilateral Filter resulted in an empty cloud. Skipping visualization." << std::endl;
     }

--- a/lib/preprocessing/main.cpp
+++ b/lib/preprocessing/main.cpp
@@ -1,0 +1,129 @@
+#include "pointcloud_preprocessing.h"
+
+int main(int argc, char **argv)
+{
+    //// Define the input PCD file path.
+    std::string filename = "/home/airsim_user/Landing-Assist-Module-LAM/lib/preprocessing/3_7_2024_dense.pcd";
+
+    /////////////////////////////////////////////////////////////////////////////////////////////////////
+    // DATA STRUCTURING
+    /////////////////////////////////////////////////////////////////////////////////////////////////////
+
+    //// Create and visualize a 2D Grid Map.
+    float gridmap_resolution = 0.1f;
+    pcl::PointCloud<pcl::PointXYZ>::Ptr grid_map = create2DGridMap(filename, gridmap_resolution);
+    if (!grid_map) {
+        return -1;
+    }
+    visualize2DGridMap(grid_map);
+
+    //// Create and visualize a 3D Grid Map.
+    double voxel_size = 0.1; // Adjust voxel size as needed.
+    VoxelGridResult voxelgrid_result = create_3d_grid(filename, voxel_size);
+    if (!voxelgrid_result.voxel_grid_ptr || !voxelgrid_result.cloud_ptr) {
+        std::cerr << "Failed to create 3d Grid." << std::endl;
+        return 1;
+    }
+    Visualize3dGridMap(voxelgrid_result.voxel_grid_ptr);
+
+    //// Create KDTree.
+    float K = 0.1f; // (Parameter can be tuned as needed.)
+    KDTreeResult kdtree_result = create_kdtree(filename, K);
+    if (!kdtree_result.kdtree || !kdtree_result.cloud_ptr) {
+        std::cerr << "Failed to create KDTree." << std::endl;
+        return 1;
+    }
+
+    //// Create Octree.
+    int max_depth = 10; // Example maximum depth.
+    OctreeResult octree_result = create_octree(filename, max_depth);
+    if (!octree_result.octree || !octree_result.cloud_ptr) {
+        std::cerr << "Failed to create Octree." << std::endl;
+        return 1;
+    }
+
+    //// Create and save Octomap.
+    std::string octomap_filename = "/home/airsim_user/Landing-Assist-Module-LAM/lib/preprocessing/pointcloud.bt";
+    double octomap_resolution = 0.05;
+    convertPointCloudToOctomap(filename, octomap_filename, octomap_resolution);
+
+    /////////////////////////////////////////////////////////////////////////////////////////////////////
+    // FILTERING
+    /////////////////////////////////////////////////////////////////////////////////////////////////////
+
+    // //// Apply voxel grid filter using Open3D and visualize.
+    double voxel_downsample_size = 0.15;
+    auto downsampled_cloud = apply_voxel_grid_filter(filename, voxel_downsample_size);
+    if (!downsampled_cloud) {
+        std::cerr << "Failed to apply voxel grid filter." << std::endl;
+        return 1;
+    }
+    VisualizeGeometry(downsampled_cloud);
+
+    //// Apply Statistical Outlier Removal (SOR) filter using Open3D and visualize.
+    int nb_neighbors = 15;
+    double std_ratio = 0.1;
+    SORFilterResult sor_result = apply_sor_filter(filename, nb_neighbors, std_ratio);
+    if (!sor_result.filtered_cloud) {
+        std::cerr << "Error: SOR filtering failed." << std::endl;
+        return 1;
+    }
+    visualize_sor_filtered_point_cloud(sor_result.original_cloud, sor_result.filtered_cloud);
+
+    // ////////////////////////////////////////////////////////////////////////////////////////////////////////
+    // /////////////////////////FILTERING USING PCL///////////////////////////////////////////////////////////
+    // //////////////////////////////////////////////////////////////////////////////////////////////////////
+
+    // //// For further filtering with PCL, load the point cloud as PointXYZI.
+    pcl::PointCloud<pcl::PointXYZI>::Ptr cloud_original(new pcl::PointCloud<pcl::PointXYZI>());
+    if (pcl::io::loadPCDFile<pcl::PointXYZI>(filename, *cloud_original) == -1) {
+        std::cerr << "[ERROR] Failed to load original PCD file: " << filename << std::endl;
+        return -1;
+    }
+    std::cout << "[INFO] Loaded " << cloud_original->size() << " points from " << filename << std::endl;
+
+    //// Downsample the PCL point cloud.
+    float leaf_size = 0.1f;
+    auto cloud_downsampled = downsamplePointCloud<pcl::PointXYZI>(cloud_original, leaf_size);
+
+    // /////////////////////////////////////////////////////////////////////////////////////////////////////
+    // // WHile using this code comment line 78 to 87 ,this function use voxeldownsampled pointcloud
+    // //// --- Radius Outlier Removal Filter (PCL) ---
+    double radius_search = 0.1;
+    int min_neighbors = 4;
+    float translation_offset = 0.0f; //change this value to visualize the filtered cloud in a different position along x axis if it 0 filtered and original pointcloud will be in the same position
+    std::cout << "[SETTINGS] filename: " << filename
+              << ", radius_search: " << radius_search
+              << ", min_neighbors: " << min_neighbors << std::endl;
+    auto cloud_radius_filtered = applyRadiusFilter<pcl::PointXYZI>(cloud_downsampled, radius_search, min_neighbors);
+    if (!cloud_radius_filtered->empty()) {
+        visualizeClouds<pcl::PointXYZI>(cloud_downsampled, cloud_radius_filtered,
+                                         "Radius Outlier Removal",
+                                         "original cloud",
+                                         "radius_filtered cloud",
+                                         2, translation_offset);
+    } else {
+        std::cerr << "[ERROR] Radius Outlier Removal resulted in an empty cloud. Skipping visualization." << std::endl;
+    }
+
+    // ////// --- Bilateral Filter (PCL) ---
+    // //// WHile using this code comment line 78 to 87 ,this function use voxeldownsampled pointcloud
+    double sigma_s = 15.0;
+    double sigma_r = 0.3;
+    float translation_offset = 0.0f; //change this value to visualize the filtered cloud in a different position along x axis if it 0 filtered and original pointcloud will be in the same position
+    std::cout << "[SETTINGS] filename: " << filename
+              << ", sigma_s: " << sigma_s
+              << ", sigma_r: " << sigma_r << std::endl;
+    auto cloud_bilateral_filtered = applyBilateralFilter<pcl::PointXYZI>(cloud_downsampled, sigma_s, sigma_r);
+    if (!cloud_bilateral_filtered->empty()) {
+        visualizeClouds<pcl::PointXYZI>(cloud_downsampled, cloud_bilateral_filtered,
+                                         "Bilateral Filter",
+                                         "original cloud",
+                                         "bilateral_filtered cloud",
+                                         2, translation_offset);
+    } else {
+        std::cerr << "[ERROR] Bilateral Filter resulted in an empty cloud. Skipping visualization." << std::endl;
+    }
+
+    return 0;
+}

--- a/lib/preprocessing/main.cpp
+++ b/lib/preprocessing/main.cpp
@@ -9,7 +9,7 @@ int main(int argc, char **argv)
     // DATA STRUCTURING
     /////////////////////////////////////////////////////////////////////////////////////////////////////
 
-    //// Create and visualize a 2D Grid Map.
+    // Create and visualize a 2D Grid Map.
     float gridmap_resolution = 0.1f;
     pcl::PointCloud<pcl::PointXYZ>::Ptr grid_map = create2DGridMap(filename, gridmap_resolution);
     if (!grid_map) {
@@ -51,7 +51,7 @@ int main(int argc, char **argv)
     // FILTERING
     /////////////////////////////////////////////////////////////////////////////////////////////////////
 
-    // //// Apply voxel grid filter using Open3D and visualize.
+    //// Apply voxel grid filter using Open3D and visualize.
     double voxel_downsample_size = 0.15;
     auto downsampled_cloud = apply_voxel_grid_filter(filename, voxel_downsample_size);
     if (!downsampled_cloud) {
@@ -86,11 +86,11 @@ int main(int argc, char **argv)
     float leaf_size = 0.1f;
     auto cloud_downsampled = downsamplePointCloud<pcl::PointXYZI>(cloud_original, leaf_size);
 
-    // /////////////////////////////////////////////////////////////////////////////////////////////////////
-    // // WHile using this code comment line 78 to 87 ,this function use voxeldownsampled pointcloud
-    // //// --- Radius Outlier Removal Filter (PCL) ---
-    double radius_search = 0.1;
-    int min_neighbors = 4;
+    // // /////////////////////////////////////////////////////////////////////////////////////////////////////
+    // // // WHile using this code comment line 78 to 87 ,this function use voxeldownsampled pointcloud
+    // // //// --- Radius Outlier Removal Filter (PCL) ---
+    double radius_search = 0.1; //0.1 to 0.3,0.3 to 0.7,0.7 to 0.15
+    int min_neighbors = 4;      // 5 to 15,10 to 30,20 to 50
     float translation_offset = 0.0f; //change this value to visualize the filtered cloud in a different position along x axis if it 0 filtered and original pointcloud will be in the same position
     std::cout << "[SETTINGS] filename: " << filename
               << ", radius_search: " << radius_search
@@ -106,10 +106,10 @@ int main(int argc, char **argv)
         std::cerr << "[ERROR] Radius Outlier Removal resulted in an empty cloud. Skipping visualization." << std::endl;
     }
 
-    // ////// --- Bilateral Filter (PCL) ---
-    // //// WHile using this code comment line 78 to 87 ,this function use voxeldownsampled pointcloud
-    double sigma_s = 15.0;
-    double sigma_r = 0.3;
+    // // ////// --- Bilateral Filter (PCL) ---
+    // // //// WHile using this code comment line 78 to 87 ,this function use voxeldownsampled pointcloud
+    double sigma_s = 15.0; // Small point clouds or detailed structures: sigma_s = 1.0 - 5.0 ,Noisy or dense point clouds: sigma_s = 5.0 - 10.0,Large or very noisy point clouds: sigma_s = 10.0 - 15.0
+    double sigma_r = 0.3;  //Preserve edges and details: sigma_r = 0.05 - 0.1, Moderate smoothing: sigma_r = 0.1 - 0.2, Heavy denoising (risk of over-smoothing): sigma_r = 0.2 - 0.3
     float translation_offset = 0.0f; //change this value to visualize the filtered cloud in a different position along x axis if it 0 filtered and original pointcloud will be in the same position
     std::cout << "[SETTINGS] filename: " << filename
               << ", sigma_s: " << sigma_s

--- a/lib/preprocessing/pointcloud_preprocessing.h
+++ b/lib/preprocessing/pointcloud_preprocessing.h
@@ -1,0 +1,476 @@
+#ifndef POINTCLOUD_PREPROCESSING_H
+#define POINTCLOUD_PREPROCESSING_H
+
+#include <iostream>
+#include <vector>
+#include <memory>
+#include <string>
+#include <algorithm>
+#include <thread>
+#include <chrono>
+
+#include <cmath>
+// Open3D headers
+#include <open3d/Open3D.h>
+// Ocotmap headers
+#include <octomap/octomap.h>
+#include <octomap/OcTree.h>
+//PCL headers
+#include <pcl/io/pcd_io.h>
+#include <pcl/filters/radius_outlier_removal.h>
+#include <pcl/filters/bilateral.h>        // Custom Bilateral Filter
+#include <pcl/filters/impl/bilateral.hpp> // Implementation
+#include <pcl/search/kdtree.h>             // Include for KdTree
+#include <pcl/visualization/pcl_visualizer.h>
+#include <pcl/point_types.h>
+#include <pcl/filters/voxel_grid.h>
+#include <pcl/filters/grid_minimum.h>
+
+//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+////////////////////////////////////////// DATA STRUCTURING GRID BASED //////////////////////////////////////////////////////////////////
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// Struct to hold both PointCloud and VoxelGrid
+struct VoxelGridResult {
+    std::shared_ptr<open3d::geometry::PointCloud> cloud_ptr;
+    std::shared_ptr<open3d::geometry::VoxelGrid> voxel_grid_ptr;
+};
+
+// // Function to load point cloud and create voxel grid
+inline VoxelGridResult create_3d_grid(const std::string& filename, double voxel_size) {
+    VoxelGridResult result;
+
+    // 1. Load the Point Cloud
+    
+    result.cloud_ptr = std::make_shared<open3d::geometry::PointCloud>();
+    if (!open3d::io::ReadPointCloud(filename, *result.cloud_ptr)) {
+        std::cerr << "Failed to read point cloud: " << filename << std::endl;
+        return result; // cloud_ptr and voxel_grid_ptr remain nullptr
+    }
+    std::cout << "Loaded point cloud with " << result.cloud_ptr->points_.size() << " points." << std::endl;
+
+    //  2. Create the Voxel Grid
+    // Open3D provides the VoxelDownSample function to create a voxel grid
+    result.voxel_grid_ptr = open3d::geometry::VoxelGrid::CreateFromPointCloud(*result.cloud_ptr, voxel_size);
+    if (result.voxel_grid_ptr->voxels_.empty()) {
+        std::cerr << "3d Voxel grid creation failed. Possibly due to an inappropriate voxel size." << std::endl;
+        result.voxel_grid_ptr = nullptr;
+        return result;
+    }
+    std::cout << "3d Voxel grid created with voxel size " << voxel_size << " and " 
+              << result.voxel_grid_ptr->voxels_.size() << " voxels." << std::endl;
+
+    return result;
+}
+// Reference link to 3d grid map : https://www.open3d.org/html/cpp_api/classopen3d_1_1geometry_1_1_voxel_grid.html#ae9239348e9de069abaf5912b92dd2b84
+
+// Function to visualize a single Open3D geometry
+inline void Visualize3dGridMap(const std::shared_ptr<const open3d::geometry::Geometry>& geometry,
+                       const std::string& window_title = "3d Grid Map",
+                       int width = 1600,
+                       int height = 900) {
+    // Create a vector to hold the geometry pointers
+    std::vector<std::shared_ptr<const open3d::geometry::Geometry>> geometries;
+    geometries.push_back(geometry);
+    
+    // Call the Open3D visualization function
+    open3d::visualization::DrawGeometries(geometries, window_title, width, height);
+}
+
+// Function to create a 2D grid map using the GridMinimum filter.
+inline pcl::PointCloud<pcl::PointXYZ>::Ptr create2DGridMap(const std::string &filename, float resolution) {
+    // Load input point cloud
+    pcl::PointCloud<pcl::PointXYZ>::Ptr input_cloud(new pcl::PointCloud<pcl::PointXYZ>());
+    if (pcl::io::loadPCDFile<pcl::PointXYZ>(filename, *input_cloud) == -1) {
+        std::cerr << "ERROR: Could not read file " << filename << std::endl;
+        return nullptr;
+    }
+    std::cout << "Loaded " << input_cloud->size() << " points from " << filename << std::endl;
+
+    // Create the GridMinimum filter object using the provided resolution.
+    // The filter will downsample the point cloud by selecting the minimum z value in each grid cell.
+    pcl::GridMinimum<pcl::PointXYZ> grid_min_filter(resolution);
+    grid_min_filter.setInputCloud(input_cloud);
+
+    // Apply the filter
+    pcl::PointCloud<pcl::PointXYZ>::Ptr grid_cloud(new pcl::PointCloud<pcl::PointXYZ>());
+    grid_min_filter.filter(*grid_cloud);
+
+    std::cout << "Created 2D grid map with " << grid_cloud->size() << " points (grid cells)." << std::endl;
+    return grid_cloud;
+}
+// Reference Link to 2d gridmap : http://pointclouds.org/documentation/classpcl_1_1_grid_minimum.html#details
+// https://github.com/PointCloudLibrary/pcl/blob/master/filters/include/pcl/filters/grid_minimum.h
+
+
+// Function to visualize a 2D grid map (represented as a point cloud)
+// using the PCLVisualizer.
+inline void visualize2DGridMap(pcl::PointCloud<pcl::PointXYZ>::Ptr cloud) {
+    if (!cloud || cloud->empty()) {
+        std::cerr << "ERROR: Cannot visualize an empty grid map." << std::endl;
+        return;
+    }
+
+    // Create a PCL Visualizer object.
+    pcl::visualization::PCLVisualizer::Ptr viewer(new pcl::visualization::PCLVisualizer("2D Grid Map Visualization"));
+    viewer->setBackgroundColor(0.0, 0.0, 0.0);
+
+    // Assign a color (e.g., green) for the grid map points.
+    pcl::visualization::PointCloudColorHandlerCustom<pcl::PointXYZ> color_handler(cloud, 0, 255, 0);
+    viewer->addPointCloud<pcl::PointXYZ>(cloud, color_handler, "grid_map");
+
+    // Set rendering properties (e.g., point size)
+    viewer->setPointCloudRenderingProperties(pcl::visualization::PCL_VISUALIZER_POINT_SIZE, 3, "grid_map");
+    viewer->addCoordinateSystem(1.0);
+
+    // Main visualization loop.
+    while (!viewer->wasStopped()) {
+        viewer->spinOnce(100);
+        std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    }
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+////////////////////////////// DATA STRUCTURING TREE STRUCTURE BASED ////////////////////////////////////////////////////////////////
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+// Function to convert point cloud to octomap
+inline void convertPointCloudToOctomap(const std::string& pcd_filename, const std::string& octomap_filename, double resolution = 0.05)
+{
+    // Load the point cloud
+    pcl::PointCloud<pcl::PointXYZ>::Ptr cloud(new pcl::PointCloud<pcl::PointXYZ>());
+    if (pcl::io::loadPCDFile<pcl::PointXYZ>(pcd_filename, *cloud) == -1)
+    {
+        std::cerr << "[ERROR] Could not read PCD file: " << pcd_filename << std::endl;
+        return;
+    }
+    std::cout << "[INFO] Loaded " << cloud->size() << " points from " << pcd_filename << std::endl;
+
+    // Create OctoMap
+
+    octomap::OcTree tree(resolution);
+
+    // Insert points into OctoMap
+    for (const auto& point : cloud->points)
+    {
+        tree.updateNode(octomap::point3d(point.x, point.y, point.z), true);
+    }
+
+    // Update inner nodes to ensure consistency
+    tree.updateInnerOccupancy();
+
+    // Save OctoMap as a binary file
+    tree.writeBinary(octomap_filename);
+    std::cout << "[INFO] OctoMap saved as " << octomap_filename << std::endl;
+}
+
+//Struct to hold kdtree
+
+struct KDTreeResult {
+    std::shared_ptr<open3d::geometry::PointCloud> cloud_ptr;
+    std::shared_ptr<open3d::geometry::KDTreeFlann> kdtree;
+    std::vector<int> neighbor_indices;
+    std::vector<double> neighbor_distances;
+};
+
+// Function to load point cloud, build KDTree
+
+inline KDTreeResult create_kdtree(const std::string& filename, float K) {
+    KDTreeResult result;
+
+    // 1. Load the Point Cloud
+    result.cloud_ptr = std::make_shared<open3d::geometry::PointCloud>();
+    if (!open3d::io::ReadPointCloud(filename, *result.cloud_ptr)) {
+        std::cerr << "Failed to read point cloud: " << filename << std::endl;
+        return result; // cloud_ptr and kdtree remain nullptr
+    }
+    std::cout << "Loaded point cloud with " << result.cloud_ptr->points_.size() << " points." << std::endl;
+
+    // 2. Build the KDTreeFlann
+    result.kdtree = std::make_shared<open3d::geometry::KDTreeFlann>();
+    result.kdtree->SetGeometry(*result.cloud_ptr);
+    std::cout << "KDTree built successfully." << std::endl;
+
+    return result;
+}
+//Reference Link :https://www.open3d.org/html/cpp_api/classopen3d_1_1geometry_1_1_k_d_tree_flann.html#ae9239348e9de069abaf5912b92dd2b84
+
+// Struct to hold octree
+struct OctreeResult {
+    std::shared_ptr<open3d::geometry::PointCloud> cloud_ptr;
+    std::shared_ptr<open3d::geometry::Octree> octree;
+    std::shared_ptr<open3d::geometry::OctreeNode> found_node;
+    std::shared_ptr<open3d::geometry::OctreeNodeInfo> node_info;
+};
+
+// Function to load point cloud, build KDTree
+inline OctreeResult create_octree(const std::string& filename, int max_depth) {
+    OctreeResult result;
+
+    // 1. Load the Point Cloud
+    result.cloud_ptr = std::make_shared<open3d::geometry::PointCloud>();
+    if (!open3d::io::ReadPointCloud(filename, *result.cloud_ptr)) {
+        std::cerr << "Failed to read point cloud: " << filename << std::endl;
+        return result; // cloud_ptr and octree remain nullptr
+    }
+    std::cout << "Loaded point cloud with " << result.cloud_ptr->points_.size() << " points." << std::endl;
+
+    // 2. Build the Octree
+    result.octree = std::make_shared<open3d::geometry::Octree>(max_depth);
+    result.octree->ConvertFromPointCloud(*result.cloud_ptr);
+    std::cout << "Octree built successfully with max depth " << max_depth << "." << std::endl;
+
+    
+    return result;
+}
+//Reference Link : https://www.open3d.org/html/cpp_api/classopen3d_1_1geometry_1_1_octree.html
+ 
+/////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+////////////////////////////////////////// FILTERING DOWN SAMPLING //////////////////////////////////////////////////////////////
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+inline std::shared_ptr<open3d::geometry::PointCloud> apply_voxel_grid_filter(
+    const std::string& filename,double voxel_size) 
+{
+
+    // 1. Load the Point Cloud
+    std::shared_ptr<open3d::geometry::PointCloud> cloud_ptr = std::make_shared<open3d::geometry::PointCloud>();
+    if (!open3d::io::ReadPointCloud(filename, *cloud_ptr)) {
+        std::cerr << "Failed to read point cloud: " << filename << std::endl;
+        return cloud_ptr; // cloud_ptr and octree remain nullptr
+    }
+    std::cout << "Loaded point cloud with " << cloud_ptr->points_.size() << " points." << std::endl;
+
+
+   
+
+    auto downsampled = cloud_ptr->VoxelDownSample(voxel_size);
+    if (downsampled->points_.empty()) {
+        std::cerr << "Warning: Downsampled cloud is empty. Try a smaller voxel size." << std::endl;
+        return nullptr;
+    }
+
+    std::cout << "Downsampled point cloud has " << downsampled->points_.size() << " points." << std::endl;
+    return downsampled;
+}
+// Reference Link: https://www.open3d.org/docs/0.11.0/cpp_api/classopen3d_1_1geometry_1_1_point_cloud.html#a50efddf2d460dccf3de46cd0d38071af
+
+// Function to visualize a single Open3D geometry
+inline void VisualizeGeometry(const std::shared_ptr<const open3d::geometry::Geometry>& geometry,
+                       const std::string& window_title = "Downsampled Voxel Grid (Voxel grid filter )",
+                       int width = 1600,
+                       int height = 900) {
+    // Create a vector to hold the geometry pointers
+    std::vector<std::shared_ptr<const open3d::geometry::Geometry>> geometries;
+    geometries.push_back(geometry);
+    
+    // Call the Open3D visualization function
+    open3d::visualization::DrawGeometries(geometries, window_title, width, height);
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+///////////////////////////////////////// FILTERING OUTLIER REMOVAL //////////////////////////////////////////////////////////////
+/////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+// Struct to hold original and filtered point clouds
+struct SORFilterResult {
+    std::shared_ptr<open3d::geometry::PointCloud> original_cloud;
+    std::shared_ptr<open3d::geometry::PointCloud> filtered_cloud;
+};
+
+// Function to apply Statistical Outlier Removal (SOR) filter
+inline SORFilterResult apply_sor_filter(
+    const std::string& filename,
+    int nb_neighbors,
+    double std_ratio)
+{
+    SORFilterResult result;
+    // 1. Load the Point Cloud
+    result.original_cloud = std::make_shared<open3d::geometry::PointCloud>();
+    
+    if (!open3d::io::ReadPointCloud(filename, *result.original_cloud)) {
+        std::cerr << "Failed to read point cloud: " << filename << std::endl;
+        return result; // result.original_cloud and octree remain nullptr
+    }
+    std::cout << "Loaded point cloud with " << result.original_cloud->points_.size() << " points." << std::endl;
+
+
+    // Apply SOR filter
+    std::vector<size_t> inlier_indices;
+    auto [sor_filtered_cloud, indices] = result.original_cloud->RemoveStatisticalOutliers(nb_neighbors, std_ratio);
+    result.filtered_cloud = sor_filtered_cloud; // Assign filtered cloud to SORFilterResult member
+
+    if (!result.filtered_cloud) {
+        std::cerr << "Warning: SOR filtering resulted in an empty cloud." << std::endl;
+        return result;  // Return early with error message printed
+    }
+
+  
+    //std::cout << "SOR filter applied. Filtered point cloud has " << sor_filtered_cloud->points_.size() << " points." << std::endl;
+    return result;
+}
+// Reference Link: https://www.open3d.org/docs/0.6.0/cpp_api/namespaceopen3d_1_1geometry.html#add56e2ec673de3b9289a25095763af6d
+// https://github.com/isl-org/Open3D/blob/main/cpp/open3d/geometry/PointCloud.cpp#L602
+
+// Function to visualize original and filtered point clouds
+inline void visualize_sor_filtered_point_cloud(
+    const std::shared_ptr<open3d::geometry::PointCloud>& original,
+    const std::shared_ptr<open3d::geometry::PointCloud>& filtered)
+{
+    if (!original || !filtered) {
+        std::cerr << "Error: One or both point clouds to visualize are null." << std::endl;
+        return;
+    }
+
+    // Assign colors for differentiation
+    auto original_colored = std::make_shared<open3d::geometry::PointCloud>(*original);
+    original_colored->PaintUniformColor(Eigen::Vector3d(1.0, 0.0, 0.0)); // Red for original
+
+    auto filtered_colored = std::make_shared<open3d::geometry::PointCloud>(*filtered);
+    filtered_colored->PaintUniformColor(Eigen::Vector3d(0.0, 1.0, 0.0)); // Green for filtered
+
+    // Prepare geometries for visualization
+    std::vector<std::shared_ptr<const open3d::geometry::Geometry>> geometries;
+    geometries.push_back(original_colored);
+    geometries.push_back(filtered_colored);
+
+    // Visualize
+    open3d::visualization::DrawGeometries(geometries, "SOR Filtere Original (Red) and Filtered (Green) Point Clouds", 1600, 900);
+}
+
+// Function to downsample a point cloud using VoxelGrid filter
+template<typename PointT>
+typename pcl::PointCloud<PointT>::Ptr downsamplePointCloud(
+    const typename pcl::PointCloud<PointT>::Ptr &cloud, 
+    float leaf_size)
+{
+    typename pcl::PointCloud<PointT>::Ptr cloud_downsampled(new pcl::PointCloud<PointT>());
+    pcl::VoxelGrid<PointT> sor;
+    sor.setInputCloud(cloud);
+    sor.setLeafSize(leaf_size, leaf_size, leaf_size);
+    sor.filter(*cloud_downsampled);
+    std::cout << "[INFO] Downsampled cloud size: " << cloud_downsampled->size() << std::endl;
+    return cloud_downsampled;
+}
+
+
+// Function to apply Radius Outlier Removal filter
+template<typename PointT>
+typename pcl::PointCloud<PointT>::Ptr applyRadiusFilter(
+    const typename pcl::PointCloud<PointT>::Ptr &cloud,
+    double radius_search,
+    int min_neighbors)
+{
+    typename pcl::PointCloud<PointT>::Ptr cloud_filtered(new pcl::PointCloud<PointT>());
+
+    pcl::RadiusOutlierRemoval<PointT> ror;
+    ror.setInputCloud(cloud);
+    ror.setRadiusSearch(radius_search);
+    ror.setMinNeighborsInRadius(min_neighbors);
+    ror.filter(*cloud_filtered);
+
+    std::cout << "[INFO] Applied Radius Outlier Removal. Filtered cloud size: " 
+              << cloud_filtered->size() << std::endl;
+
+    return cloud_filtered;
+}
+//// Referencle Link : http://pointclouds.org/documentation/classpcl_1_1_radius_outlier_removal.html
+////                       https://github.com/PointCloudLibrary/pcl/blob/master/filters/src/radius_outlier_removal.cpp#L47
+
+
+
+/////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+////////////////////////////////////////// FILTERING SMOOTHING /////////////////////////////////////////////////////////////////
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+// Function to apply Bilateral Filter
+template<typename PointT>
+typename pcl::PointCloud<PointT>::Ptr applyBilateralFilter(
+    const typename pcl::PointCloud<PointT>::Ptr &cloud,
+    double sigma_s,
+    double sigma_r) // Changed sigma_r to double
+{
+    typename pcl::PointCloud<PointT>::Ptr cloud_filtered(new pcl::PointCloud<PointT>());
+
+    // Initialize the bilateral filter
+    pcl::BilateralFilter<PointT> bilateral_filter;
+    
+    // Set the input cloud
+    bilateral_filter.setInputCloud(cloud);
+    
+    // Set filter parameters
+    bilateral_filter.setHalfSize(sigma_s);  // Spatial standard deviation
+    bilateral_filter.setStdDev(sigma_r);     // Range standard deviation
+    
+    // Create and set the search method
+    typename pcl::search::KdTree<PointT>::Ptr tree(new pcl::search::KdTree<PointT>());
+    bilateral_filter.setSearchMethod(tree);
+    
+    // Apply the filter
+    bilateral_filter.filter(*cloud_filtered); // Use filter() as per implementation
+    
+    std::cout << "[INFO] Applied Bilateral Filter. Filtered cloud size: " 
+              << cloud_filtered->size() << std::endl;
+
+    return cloud_filtered;
+}
+//   Reference Link: https://pointclouds.org/documentation/classpcl_1_1_bilateral_filter.html
+//                   https://github.com/PointCloudLibrary/pcl/blob/master/filters/include/pcl/filters/bilateral.h#L56
+
+// Function to visualize two point clouds (as defined above)
+template<typename PointT>
+void visualizeClouds(
+    const typename pcl::PointCloud<PointT>::Ptr &cloud_downsampled,
+    const typename pcl::PointCloud<PointT>::Ptr &filtered_cloud,
+    const std::string &window_title,
+    const std::string &original_cloud_name,
+    const std::string &filtered_cloud_name,
+    int point_size,
+    float translation_offset)
+{
+    pcl::visualization::PCLVisualizer::Ptr viewer(new pcl::visualization::PCLVisualizer(window_title));
+    viewer->setBackgroundColor(1.0, 1.0, 1.0); // White background
+
+    // Translate the filtered cloud to add a visible space between the two clouds
+    typename pcl::PointCloud<PointT>::Ptr translated_filtered_cloud(new pcl::PointCloud<PointT>(*filtered_cloud));
+
+    for (auto &point : translated_filtered_cloud->points)
+    {
+        point.x += translation_offset; // Translate the filtered cloud along the x-axis
+        //point.y += translation_offset; // Translate the filtered cloud along the y-axis
+        //point.z += translation_offset; // Translate the filtered cloud along the z-axis
+
+    }
+
+    // Original cloud in green
+    pcl::visualization::PointCloudColorHandlerCustom<PointT> orig_color(cloud_downsampled,0 ,255 , 0); // green
+        // Filtered cloud in red
+    pcl::visualization::PointCloudColorHandlerCustom<PointT> filt_color(translated_filtered_cloud,255, 0, 0); // red
+
+        // Add the original point cloud to the viewer
+    viewer->addPointCloud<PointT>(cloud_downsampled, orig_color, original_cloud_name);
+        // Set the point size for the original cloud
+    viewer->setPointCloudRenderingProperties(pcl::visualization::PCL_VISUALIZER_POINT_SIZE,
+                                               point_size,
+                                               original_cloud_name);
+
+        // Add the filtered point cloud to the viewer
+    viewer->addPointCloud<PointT>(translated_filtered_cloud, filt_color, filtered_cloud_name);
+        // Set the point size for the filtered cloud
+    viewer->setPointCloudRenderingProperties(pcl::visualization::PCL_VISUALIZER_POINT_SIZE,
+                                                  point_size,
+                                                 filtered_cloud_name);
+    //}
+
+    // Add a coordinate system (scale = 1.0)
+    viewer->addCoordinateSystem(1.0);
+    //viewer->initCameraParameters();
+
+    // Main loop to keep the visualizer window open
+    while (!viewer->wasStopped())
+    {
+        viewer->spinOnce(100);
+        std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    }
+}
+
+#endif // POINTCLOUD_PREPROCESSING_H

--- a/lib/preprocessing/test_pointcloud_preprocessing.cpp
+++ b/lib/preprocessing/test_pointcloud_preprocessing.cpp
@@ -1,0 +1,167 @@
+#include "pointcloud_preprocessing.h"
+#include <gtest/gtest.h>
+#include <fstream>
+
+// Change this file path if needed.
+static const std::string filename = "/home/airsim_user/Landing-Assist-Module-LAM/lib/preprocessing/3_7_2024_dense.pcd";
+
+// Helper function to check if a file exists.
+bool fileExists(const std::string &path) {
+    std::ifstream f(path.c_str());
+    return f.good();
+}
+
+////////////////////////////////////////////////////////////
+// TESTS for DATA STRUCTURING functions
+////////////////////////////////////////////////////////////
+
+TEST(DataStructuring, Create2DGridMap) {
+    float gridmap_resolution = 0.1f;
+    auto grid_map = create2DGridMap(filename, gridmap_resolution);
+    // Check that the returned pointer is not null and has points.
+    EXPECT_NE(grid_map, nullptr);
+    if(grid_map)
+    {
+        EXPECT_GT(grid_map->size(), 0);
+    }
+}
+
+TEST(DataStructuring, Create3DGridMap) {
+    double voxel_size = 0.1;
+    VoxelGridResult voxelgrid_result = create_3d_grid(filename, voxel_size);
+    EXPECT_NE(voxelgrid_result.cloud_ptr, nullptr);
+    EXPECT_NE(voxelgrid_result.voxel_grid_ptr, nullptr);
+    if(voxelgrid_result.cloud_ptr)
+    {
+        EXPECT_GT(voxelgrid_result.cloud_ptr->points_.size(), 0);
+    }
+    if(voxelgrid_result.voxel_grid_ptr)
+    {
+        EXPECT_GT(voxelgrid_result.voxel_grid_ptr->voxels_.size(), 0);
+    }
+}
+
+TEST(DataStructuring, CreateKDTree) {
+    float K = 0.1f;
+    KDTreeResult kdtree_result = create_kdtree(filename, K);
+    EXPECT_NE(kdtree_result.cloud_ptr, nullptr);
+    EXPECT_NE(kdtree_result.kdtree, nullptr);
+    if(kdtree_result.cloud_ptr)
+    {
+        EXPECT_GT(kdtree_result.cloud_ptr->points_.size(), 0);
+    }
+}
+
+TEST(DataStructuring, CreateOctree) {
+    int max_depth = 10;
+    OctreeResult octree_result = create_octree(filename, max_depth);
+    EXPECT_NE(octree_result.cloud_ptr, nullptr);
+    EXPECT_NE(octree_result.octree, nullptr);
+    if(octree_result.cloud_ptr)
+    {
+        EXPECT_GT(octree_result.cloud_ptr->points_.size(), 0);
+    }
+}
+
+TEST(DataStructuring, ConvertPointCloudToOctomap) {
+    std::string octomap_filename = "/home/airsim_user/Landing-Assist-Module-LAM/lib/preprocessing/pointcloud.bt";
+    double octomap_resolution = 0.05;
+    // Call the conversion function.
+    convertPointCloudToOctomap(filename, octomap_filename, octomap_resolution);
+    // Check that the octomap file was created.
+    EXPECT_TRUE(fileExists(octomap_filename));
+}
+
+////////////////////////////////////////////////////////////
+// TESTS for FILTERING functions
+////////////////////////////////////////////////////////////
+
+TEST(Filtering, ApplyVoxelGridFilter) {
+    double voxel_downsample_size = 0.15;
+    auto downsampled_cloud = apply_voxel_grid_filter(filename, voxel_downsample_size);
+    EXPECT_NE(downsampled_cloud, nullptr);
+    if(downsampled_cloud)
+    {
+        EXPECT_GT(downsampled_cloud->points_.size(), 0);
+    }
+}
+
+TEST(Filtering, ApplySORFilter) {
+    int nb_neighbors = 15;
+    double std_ratio = 0.1;
+    SORFilterResult sor_result = apply_sor_filter(filename, nb_neighbors, std_ratio);
+    EXPECT_NE(sor_result.original_cloud, nullptr);
+    EXPECT_NE(sor_result.filtered_cloud, nullptr);
+    if(sor_result.original_cloud)
+    {
+        EXPECT_GT(sor_result.original_cloud->points_.size(), 0);
+    }
+    if(sor_result.filtered_cloud)
+    {
+        // In many cases the filtered cloud should be smaller than the original.
+        EXPECT_LT(sor_result.filtered_cloud->points_.size(),
+                  sor_result.original_cloud->points_.size());
+    }
+}
+
+////////////////////////////////////////////////////////////
+// TESTS for PCL-based filtering functions
+////////////////////////////////////////////////////////////
+
+TEST(PCLFiltering, DownsamplePointCloud) {
+    // Load the PCL point cloud.
+    pcl::PointCloud<pcl::PointXYZI>::Ptr cloud_original(new pcl::PointCloud<pcl::PointXYZI>());
+    int load_ret = pcl::io::loadPCDFile<pcl::PointXYZI>(filename, *cloud_original);
+    EXPECT_NE(load_ret, -1) << "Failed to load original PCD file.";
+    EXPECT_GT(cloud_original->size(), 0);
+
+    float leaf_size = 0.1f;
+    auto cloud_downsampled = downsamplePointCloud<pcl::PointXYZI>(cloud_original, leaf_size);
+    EXPECT_NE(cloud_downsampled, nullptr);
+    if(cloud_downsampled)
+    {
+        EXPECT_GT(cloud_downsampled->size(), 0);
+    }
+}
+
+TEST(PCLFiltering, ApplyRadiusFilter) {
+    // Load original cloud.
+    pcl::PointCloud<pcl::PointXYZI>::Ptr cloud_original(new pcl::PointCloud<pcl::PointXYZI>());
+    int load_ret = pcl::io::loadPCDFile<pcl::PointXYZI>(filename, *cloud_original);
+    EXPECT_NE(load_ret, -1) << "Failed to load original PCD file.";
+    EXPECT_GT(cloud_original->size(), 0);
+
+    float leaf_size = 0.1f;
+    auto cloud_downsampled = downsamplePointCloud<pcl::PointXYZI>(cloud_original, leaf_size);
+    double radius_search = 0.1;
+    int min_neighbors = 4;
+    auto cloud_radius_filtered = applyRadiusFilter<pcl::PointXYZI>(cloud_downsampled, radius_search, min_neighbors);
+    // Check that the filtered cloud is not empty.
+    EXPECT_FALSE(cloud_radius_filtered->empty());
+}
+
+TEST(PCLFiltering, ApplyBilateralFilter) {
+    // Load original cloud.
+    pcl::PointCloud<pcl::PointXYZI>::Ptr cloud_original(new pcl::PointCloud<pcl::PointXYZI>());
+    int load_ret = pcl::io::loadPCDFile<pcl::PointXYZI>(filename, *cloud_original);
+    EXPECT_NE(load_ret, -1) << "Failed to load original PCD file.";
+    EXPECT_GT(cloud_original->size(), 0);
+
+    float leaf_size = 0.1f;
+    auto cloud_downsampled = downsamplePointCloud<pcl::PointXYZI>(cloud_original, leaf_size);
+    double sigma_s = 15.0;
+    double sigma_r = 0.3;
+    auto cloud_bilateral_filtered = applyBilateralFilter<pcl::PointXYZI>(cloud_downsampled, sigma_s, sigma_r);
+    // Check that the bilateral filtered cloud is not empty.
+    EXPECT_FALSE(cloud_bilateral_filtered->empty());
+}
+
+////////////////////////////////////////////////////////////
+// Main function for Google Test
+////////////////////////////////////////////////////////////
+
+int main(int argc, char **argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    // Note: We do not call visualization functions here in order not to block the tests.
+    return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
The code includes examples for:
- Loading point clouds.
- Downsampling using a voxel grid filter.
- Creating 2D and 3D grid maps.
- Building KD-Trees and Octrees.
- Applying filters like Statistical Outlier Removal (SOR), Radius Outlier Removal, and Bilateral filtering.
- Visualizing the results using both Open3D and PCL visualizers.
- Converting point clouds to OctoMap format.